### PR TITLE
Add Cache Busting in Production Code

### DIFF
--- a/webpack.mix.js
+++ b/webpack.mix.js
@@ -16,3 +16,7 @@ mix.js([
     ], 'public/js/app.js')
    .sass('resources/assets/sass/app.scss', 'public/css/app.css')
    .sourceMaps();
+
+if (mix.inProduction()) {
+    mix.version();
+}


### PR DESCRIPTION
When Laravel Mix is run in production, the compiled CSS and JS files will be hashed to version them.

Docs: https://github.com/JeffreyWay/laravel-mix/blob/master/docs/versioning.md

This might be adding complexity that is not needed, so I want to get thoughts before we merge it in.