### PR TITLE
Make FASET Logo smaller

### DIFF
--- a/resources/views/faset.blade.php
+++ b/resources/views/faset.blade.php
@@ -7,13 +7,10 @@
   </head>
   <body id="faset">
     <div class="container">
-      <div class="jumbotron jumbotron-fluid">
-        <div class="container">
-          <div class="row">
-            <div class="col-md-8 offset-md-2">
-              <img class="img-fluid" src="{{ asset('img/faset_form_header.svg') }}">
-            </div>
-          </div>
+      <div class="row">
+        <div class="col-md-8 offset-md-2">
+          <img class="mt-2 px-5 img-fluid" src="{{ asset('img/faset_form_header.svg') }}">
+          <hr class="my-4">
         </div>
       </div>
 


### PR DESCRIPTION
Removed Jumbotron to make the RoboJackets logo smaller to bring all the form content above the fold on WIndows @1920x1080 monitors. Fixes #40