### PR TITLE
Change client behavior when a duplicate dues request is submitted

### DIFF
--- a/resources/assets/js/components/dues/DuesRequiredInfo.vue
+++ b/resources/assets/js/components/dues/DuesRequiredInfo.vue
@@ -128,7 +128,7 @@
           .catch(error => {
             console.log(error.response.status);
             if (error.response.status == 400) {
-              sweetAlert("Not Again!", "You've already submitted a dues request. Go ahead see an officer or project manager to submit payment.", "info");
+              this.$emit("next");
             } else {
               console.log(error);
               sweetAlert("Connection Error", "Unable to save data. Check your internet connection or try refreshing the page.", "error");


### PR DESCRIPTION
Instead of presenting the user with an error, it will proceed through the dues sequence again, which has no consequences