### PR TITLE
Implement Square Payment Validation

### DIFF
--- a/app/DuesTransaction.php
+++ b/app/DuesTransaction.php
@@ -84,4 +84,12 @@ class DuesTransaction extends Model
     {
         return $query->doesntHave('payment');
     }
+
+    /**
+     * Get the Payable amount
+     */
+    public function getPayableAmount()
+    {
+        return ($this->package->cost) ?: null;
+    }
 }

--- a/app/Event.php
+++ b/app/Event.php
@@ -41,4 +41,12 @@ class Event extends Model
     {
         return $this->morphMany('App\Attendance', 'attendable');
     }
+
+    /**
+     * Get the Payable amount
+     */
+    public function getPayableAmount()
+    {
+        return ($this->price) ?: null;
+    }
 }

--- a/app/Http/Controllers/PaymentController.php
+++ b/app/Http/Controllers/PaymentController.php
@@ -7,10 +7,13 @@ use App\Payment;
 use App\Event;
 use App\DuesTransaction;
 use SquareConnect\Api\CheckoutApi;
+use SquareConnect\Api\TransactionsApi;
 use SquareConnect\Configuration;
 use SquareConnect\Model\CreateCheckoutRequest;
 use SquareConnect\Model\CreateOrderRequest;
 use App\Notifications\Payment\ConfirmationNotification as Confirm;
+use Validator;
+use Log;
 
 class PaymentController extends Controller
 {
@@ -261,7 +264,7 @@ class PaymentController extends Controller
             "order" => $order,
             "merchant_support_email" => "treasurer@robojackets.org",
             "pre_populate_buyer_email" => $email,
-//            "redirect_url" => route('payments.complete')
+            "redirect_url" => route('payments.complete')
         ]);
 
         try {
@@ -283,6 +286,104 @@ class PaymentController extends Controller
      */
     public function handleSquareResponse(Request $request)
     {
-        //
+        //Make sure we have all of the necessary parameters from Square
+        $validator = Validator::make($request->all(), [
+            'checkoutId' => 'required',
+            'transactionId' => 'required',
+            'referenceId' => 'required'
+        ]);
+
+        //If we don't, something fishy is going on.
+        if ($validator->fails()) {
+            Log::warning(get_class() . " - Missing parameter in Square response\n");
+            return response(view('errors.generic',
+                [
+                    'error_code' => 500,
+                    'error_message' => 'Missing parameter in Square response.'
+                ]), 500);
+        }
+        
+        $checkout_id = $request->input('checkoutId');
+        $server_txn_id = $request->input('transactionId');
+        $client_txn_id = $request->input('referenceId');
+        
+        //Check to make sure the reference ID is "PMTXXXX"
+        $payment_id = substr($client_txn_id, 3);
+        Log::debug(get_class() . " - Stripping Reference ID '$client_txn_id' to '$payment_id'");
+        if (!is_numeric($payment_id) || substr($client_txn_id, 0, 3) != "PMT") {
+            Log::error(get_class() . " - Invalid Payment ID in Square response '$payment_id'");
+            return response(view('errors.generic',
+                [
+                    'error_code' => 500,
+                    'error_message' => 'Invalid Payment ID in Square response.'
+                ]), 500);
+        }
+        
+        //Find the payment
+        $payment = Payment::find($payment_id);
+        if (!$payment) {
+            Log::warning(get_class() . " - Error locating Payment '$payment_id'");
+            return response(view('errors.generic',
+                [
+                    'error_code' => 500,
+                    'error_message' => 'Unable to locate payment.'
+                ]), 500);
+        }
+        Log::debug(get_class() . " - Found Payment '$payment_id'");
+        
+        //Prepare Square API Call
+        $txnClient = new TransactionsApi();
+        $location = (\App::environment('production')) ?
+            config('payment.square.location_id') :
+            config('payment.square.location_id_test');
+        $token = (\App::environment('production')) ?
+            config('payment.square.token') :
+            config('payment.square.token_test');
+        Configuration::getDefaultConfiguration()->setAccessToken($token);
+        
+        //Query Square API to get authoritative data
+        try {
+            Log::debug(get_class() . " - Querying Square for Transaction '$server_txn_id'");
+            $square_txn = $txnClient->retrieveTransaction($location, $server_txn_id);
+        } catch (\Exception $e) {
+            $error = $e->getMessage();
+            Log::error(get_class() . " - Error querying Square transaction\n$error");
+            return response(view('errors.generic',
+                [
+                    'error_code' => 500,
+                    'error_message' => 'Error querying Square transaction'
+                ]), 500);
+        }
+        Log::debug(get_class() . " - Retrieved Square Transaction '$server_txn_id'");
+        
+        $tenders = $square_txn->getTransaction()->getTenders();
+        $amount = $tenders[0]->getAmountMoney()->getAmount() / 100;
+        $created_at = $square_txn->getTransaction()->getCreatedAt();
+        Log::debug(get_class() . " - Square Transaction Details for '$server_txn_id'\n" .
+            "Amount: $amount | Txn Date: $created_at");
+        
+        //Compare received payment amount to expected payment amount
+        $payable = $payment->payable;
+        $expected_amount = $payable->getPayableAmount();
+        $difference = $amount - $expected_amount;
+        if ($difference != 3) {
+            $message = "Payment Discrepancy Found for ID $payment->id\n" .
+                "Expected: $expected_amount | Actual: $amount | Server Txn ID: $server_txn_id";
+            Log::error(get_class() . " - " . $message);
+            return response(view('errors.generic',
+                [
+                    'error_code' => 500,
+                    'error_message' => 'Payment discrepancy found. Please contact the Treasurer for assistance.'
+                ]), 500);
+        }
+        
+        $payment->amount = $amount;
+        $payment->checkout_id = $checkout_id;
+        $payment->server_txn_id = $server_txn_id;
+        $payment->client_txn_id = $client_txn_id;
+        $payment->notes = "";
+        $payment->save();
+        
+        Log::debug(get_class() . "Payment $payment->id Updated Successfully");
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,8 @@
         "predis/predis": "~1.0",
         "spatie/laravel-permission": "^2.6",
         "square/connect": "^2.5",
-        "subfission/cas": "^2.0"
+        "subfission/cas": "^2.0",
+        "uxweb/sweet-alert": "^1.4"
     },
     "require-dev": {
         "fzaninotto/faker": "~1.4",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "f33361c2592c29144a3f44065d611e23",
+    "content-hash": "593c14274a6bd00d479c2c8f30b801d0",
     "packages": [
         {
             "name": "bugsnag/bugsnag",
@@ -3044,6 +3044,67 @@
             "description": "CssToInlineStyles is a class that enables you to convert HTML-pages/files into HTML-pages/files with inline styles. This is very useful when you're sending emails.",
             "homepage": "https://github.com/tijsverkoyen/CssToInlineStyles",
             "time": "2016-09-20T12:50:39+00:00"
+        },
+        {
+            "name": "uxweb/sweet-alert",
+            "version": "1.4.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/uxweb/sweet-alert.git",
+                "reference": "92519b916755d673f92343767edd06110b167d05"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/uxweb/sweet-alert/zipball/92519b916755d673f92343767edd06110b167d05",
+                "reference": "92519b916755d673f92343767edd06110b167d05",
+                "shasum": ""
+            },
+            "require": {
+                "illuminate/session": "~5.0",
+                "illuminate/support": "~5.0",
+                "php": ">=5.4.0"
+            },
+            "require-dev": {
+                "mockery/mockery": "^0.9.5",
+                "phpunit/phpunit": "^5.5"
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "providers": [
+                        "UxWeb\\SweetAlert\\SweetAlertServiceProvider"
+                    ],
+                    "aliases": {
+                        "Alert": "UxWeb\\SweetAlert\\SweetAlert"
+                    }
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "UxWeb\\SweetAlert\\": "src/SweetAlert/"
+                },
+                "files": [
+                    "src/SweetAlert/functions.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Uziel Bueno",
+                    "email": "ux.webs@gmail.com"
+                }
+            ],
+            "description": "A simple PHP package to show Sweet Alerts with the Laravel Framework",
+            "keywords": [
+                "alert",
+                "laravel",
+                "notifier",
+                "sweet"
+            ],
+            "time": "2017-09-10T17:14:08+00:00"
         },
         {
             "name": "vlucas/phpdotenv",

--- a/config/app.php
+++ b/config/app.php
@@ -182,6 +182,7 @@ return [
         Laravel\Tinker\TinkerServiceProvider::class,
         Subfission\Cas\CasServiceProvider::class,
         Bugsnag\BugsnagLaravel\BugsnagServiceProvider::class,
+        UxWeb\SweetAlert\SweetAlertServiceProvider::class,
 
         /*
          * Application Service Providers...
@@ -244,6 +245,7 @@ return [
         'View' => Illuminate\Support\Facades\View::class,
         'Cas' => Subfission\Cas\Facades\Cas::class,
         'Bugsnag' => Bugsnag\BugsnagLaravel\Facades\Bugsnag::class,
+        'Alert' => UxWeb\SweetAlert\SweetAlert::class,
 
     ],
 

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -65,4 +65,9 @@
     @include('layouts/footer')
   </body>
   <script src="{{ mix('/js/app.js') }}"></script>
+  @if (Session::has('sweet_alert.alert'))
+    <script>
+        swal({!! Session::pull('sweet_alert.alert') !!});
+    </script>
+  @endif
 </html>


### PR DESCRIPTION
Closes #217 

- Adds validation of a Square payment post-checkout process by accepting HTTP parameters in Square's redirect and querying the Square database for details
- Adds `getPayableAmount()` to `Payable` models for easier access of dollar amounts
- Adds support for triggering SweetAlert popups from controllers