### PR TITLE
Fix CAS Middleware Bug

### DIFF
--- a/app/Http/Middleware/CASAuthenticate.php
+++ b/app/Http/Middleware/CASAuthenticate.php
@@ -36,7 +36,8 @@ class CASAuthenticate
      */
     public function handle($request, Closure $next)
     {
-        if (!Auth::check()) {
+        //Check to ensure the request isn't already authenticated through the API guard
+        if (!Auth::guard('api')->check()) {
             if ($this->cas->isAuthenticated()) {
                 $user = $this->createOrUpdateCASUser($request);
                 if (is_a($user, "App\User")) {


### PR DESCRIPTION
Now in the `cas.force` middleware, instead of just checking if the user is authenticated period, it’s checking first if the user has authenticated through the API guard. If not, then it forces CAS. If the user is already auth’d through API guard, it passes the request on.