### PR TITLE
More Multiple Payment Fixes

### DIFF
--- a/app/DuesTransaction.php
+++ b/app/DuesTransaction.php
@@ -82,16 +82,14 @@ class DuesTransaction extends Model
     /**
      * Scope a query to only include pending transactions.
      * Pending defined as no payments, or payments that do not sum to payable amount
+     * for a currently active DuesPackage
      *
      * @param \Illuminate\Database\Eloquent\Builder $query
      * @return \Illuminate\Database\Eloquent\Builder
      */
     public function scopePending($query)
     {
-        return $query->doesntHave('payment')
-            ->orWhereHas('payment', function ($q) {
-                $q->where('amount', '=', 0);
-            });
+        return $query->current()->unpaid();
     }
 
     /**

--- a/app/Http/Controllers/DashboardController.php
+++ b/app/Http/Controllers/DashboardController.php
@@ -19,8 +19,7 @@ class DashboardController extends Controller
         $user = $request->user();
         $transactionsQuery = DuesTransaction::where('user_id', $user->id)
             ->whereHas('package', function ($q) {
-                $q->whereDate('effective_start', '<=', date('Y-m-d'))
-                    ->whereDate('effective_end', '>=', date('Y-m-d'));
+                $q->active();
             });
         $needsTransaction = (count($transactionsQuery->get()) == 0);
         

--- a/app/Http/Controllers/PaymentController.php
+++ b/app/Http/Controllers/PaymentController.php
@@ -118,6 +118,7 @@ class PaymentController extends Controller
                 })
                 ->whereHas('payment', function ($q) {
                     $q->where('amount', 0.00);
+                    $q->where('method', 'square');
                 })->first();
 
             if ($transactZeroPmt) {

--- a/app/User.php
+++ b/app/User.php
@@ -174,8 +174,8 @@ class User extends Authenticatable
             $pkgIsActive = $lastDuesTransaction->package->is_active;
             $hasPayment = ($lastDuesTransaction->payment()->exists());
             if ($hasPayment) {
-                $finishedPayment = ($lastDuesTransaction->payment->first()->amount != 0);
-                return ($finishedPayment && $pkgIsActive);
+                $paidTotal = ($lastDuesTransaction->payment->sum('amount') == $lastDuesTransaction->getPayableAmount());
+                return ($paidTotal && $pkgIsActive);
             } else {
                 return false;
             }


### PR DESCRIPTION
- Closes #252 
- Adds `expired` status to DuesTransactions for an inactive package
- Adds `paid()`, `unpaid()`, and `current()` local scopes to DuesTransaction model
- Modifies `pending()` local scope for DuesTransaction model to return current and unpaid transactions
- Cleans up some code/logic for the dashboard queries
- Adds a check for Square transaction method when hunting for $0 payments to re-use
- Fixes logic for member active/inactive status based upon dues payment