### PR TITLE
Show cost in DuesPackage drop-down menu and add loading/empty states

### DIFF
--- a/resources/assets/js/components/dues/DuesRequiredInfo.vue
+++ b/resources/assets/js/components/dues/DuesRequiredInfo.vue
@@ -60,8 +60,10 @@
           <label for="duesPackage" class="col-sm-2 col-form-label">Dues Term</label>
           <div class="col-sm-10 col-lg-4">
             <select id="duesPackage" v-model="duesPackageChoice" class="custom-select" :class="{ 'is-invalid': $v.duesPackageChoice.$error }" @input="$v.duesPackageChoice.$touch()">
-              <option value="" style="display:none">Select One</option>
-              <option v-for="duesPackage in duesPackages" :value="duesPackage.id">{{duesPackage.name}}</option>
+              <option value="" style="display:none" v-if="!duesPackages">Loading...</option>
+              <option value="" style="display:none" v-if="duesPackages && duesPackages.length === 0">No Dues Packages Available</option>
+              <option value="" style="display:none" v-if="duesPackages && duesPackages.length > 0">Select One</option>
+              <option v-for="duesPackage in duesPackages" :value="duesPackage.id">{{duesPackage.name}} - ${{duesPackage.cost}}</option>
             </select>
             <div class="invalid-feedback">
               Select a dues package.
@@ -96,7 +98,7 @@
           {value: "xxl", text: "XXL"},
           {value: "xxxl", text: "XXXL"},
         ],
-        duesPackages: [],
+        duesPackages: null,
         duesPackageChoice: ''
       }
     },


### PR DESCRIPTION
I updated the Dues Package selection dropdown to show status messages for "Loading..." and "No Dues Packages Available" states.  As part of this change, the initial value of the `duesPackage` property in DuesRequiredInfo.vue is no longer an empty array; it's now `null`.  This made it easy to distinguish between the three states of 1) data is loading, 2) data is loaded but there's nothing to select, or 3) data is loaded and there are items to choose from.

Closes #336 