### PR TITLE
Clickable table rows (updated)

### DIFF
--- a/resources/assets/js/components/Datatable.vue
+++ b/resources/assets/js/components/Datatable.vue
@@ -13,6 +13,7 @@
    *  @props dataObject: The data object that will be used to populate the table if no dataUrl is supplied
    *  @props columns: Columns config data for DataTables, API: https://datatables.net/reference/option/
    *  @props dataPath: the top level key that holds the data
+   *  @props dataLink: The root pathname used for linking URLs from children in the table; defaults to the window's current pathname
    *  @props delete: boolean value indicating if there should be delete buttons on each row
    */
 export default {

--- a/resources/assets/js/components/Datatable.vue
+++ b/resources/assets/js/components/Datatable.vue
@@ -21,6 +21,10 @@ export default {
     dataUrl: String,
     dataObject: Array,
     dataPath: String,
+    dataLink: {
+      type: String,
+      default: window.location.pathname
+    },
     id: {
       type: String,
       default: 'DataTable',
@@ -44,13 +48,18 @@ export default {
           dom: customDom,
           buttons: ['copy', 'csv', 'excel', 'print'],
         });
-        let dataPath = this.dataPath;
-        //make each row clickable
-        $('#' + this.id + ' tbody tr').click(function() {
-          const rowID = this.childNodes[0].innerText;
-          const path = window.location.pathname;
-          window.location.pathname = path.substring(0, path.lastIndexOf('/') + 1) + dataPath + '/' + rowID;
-        });
+        this.makeRowsClickable();
+      },
+      makeRowsClickable: function () {
+        const path = this.dataLink;
+        if (this.tableData.length) {
+          const rowID = '#' + this.id + ' tbody tr';
+          $(rowID).click(function() {
+            window.location.pathname = path + (path.lastIndexOf('/') === path.length - 1 ? '' : '/')
+              + this.childNodes[0].innerText;
+          });
+          $(rowID).css('cursor', 'pointer');
+        }
       },
     };
   },
@@ -80,6 +89,8 @@ export default {
 
         this.table.clear();
         this.table.rows.add(this.tableData).draw();
+
+        this.makeRowsClickable();
       }
     },
   },

--- a/resources/assets/js/components/Datatable.vue
+++ b/resources/assets/js/components/Datatable.vue
@@ -23,7 +23,7 @@ export default {
     dataPath: String,
     dataLink: {
       type: String,
-      default: window.location.pathname
+      default: window.location.pathname,
     },
     id: {
       type: String,
@@ -50,13 +50,13 @@ export default {
         });
         this.makeRowsClickable();
       },
-      makeRowsClickable: function () {
+      makeRowsClickable: function() {
         const path = this.dataLink;
         if (this.tableData.length) {
           const rowID = '#' + this.id + ' tbody tr';
           $(rowID).click(function() {
-            window.location.pathname = path + (path.lastIndexOf('/') === path.length - 1 ? '' : '/')
-              + this.childNodes[0].innerText;
+            window.location.pathname =
+              path + (path.lastIndexOf('/') === path.length - 1 ? '' : '/') + this.childNodes[0].innerText;
           });
           $(rowID).css('cursor', 'pointer');
         }

--- a/resources/assets/js/components/wrappers/DuesAdminTable.vue
+++ b/resources/assets/js/components/wrappers/DuesAdminTable.vue
@@ -11,14 +11,7 @@ export default {
   data() {
     return {
       tableConfig: [
-        {
-          title: 'ID',
-          data: 'id',
-          render: function(data, type, row) {
-            var link = "<a href='/admin/dues/" + data + "'>" + data + '</a>';
-            return type === 'display' ? link : data;
-          },
-        },
+        { title: 'ID', data: 'id' },
         { title: 'Timestamp', data: 'created_at' },
         { title: 'Name', data: 'user.name' },
         { title: 'Dues Package', data: 'package.name' },

--- a/resources/assets/js/components/wrappers/EventsAdminTable.vue
+++ b/resources/assets/js/components/wrappers/EventsAdminTable.vue
@@ -11,14 +11,7 @@ export default {
   data() {
     return {
       tableConfig: [
-        {
-          title: 'ID',
-          data: 'id',
-          render: function(data, type, row) {
-            var link = "<a href='/admin/events/" + data + "'>" + data + '</a>';
-            return type === 'display' ? link : data;
-          },
-        },
+        { title: 'ID', data: 'id' },
         { title: 'Name', data: 'name' },
         { title: 'Organizer', data: 'organizer_name' },
       ],

--- a/resources/assets/js/components/wrappers/FasetAdminTable.vue
+++ b/resources/assets/js/components/wrappers/FasetAdminTable.vue
@@ -11,14 +11,7 @@ export default {
   data() {
     return {
       tableConfig: [
-        {
-          title: 'ID',
-          data: 'id',
-          render: function(data, type, row) {
-            var link = "<a href='faset/" + data + "'>" + data + '</a>';
-            return type === 'display' ? link : data;
-          },
-        },
+        { title: 'ID', data: 'id' },
         { title: 'Timestamp', data: 'created_at' },
         { title: 'Name', data: 'faset_name' },
         { title: 'Email', data: 'faset_email' },

--- a/resources/assets/js/components/wrappers/PendingDuesTable.vue
+++ b/resources/assets/js/components/wrappers/PendingDuesTable.vue
@@ -2,6 +2,7 @@
   <datatable id="dues-admin-table"
     data-url="/api/v1/dues/transactions/pending"
     data-path="dues_transactions"
+    data-link="/admin/dues/"
     :columns="tableConfig">
   </datatable>
 </template>
@@ -11,14 +12,7 @@ export default {
   data() {
     return {
       tableConfig: [
-        {
-          title: 'ID',
-          data: 'id',
-          render: function(data, type, row) {
-            var link = "<a href='/admin/dues/" + data + "'>" + data + '</a>';
-            return type === 'display' ? link : data;
-          },
-        },
+        { title: 'ID', data: 'id' },
         { title: 'Timestamp', data: 'updated_at' },
         { title: 'Name', data: 'user.name' },
         { title: 'Dues Package', data: 'package.name' },

--- a/resources/assets/js/components/wrappers/SwagTable.vue
+++ b/resources/assets/js/components/wrappers/SwagTable.vue
@@ -2,13 +2,15 @@
   <datatable v-if="this.tableFilter == 'index'"
              id="swag-index-table" 
              data-url="/api/v1/dues/transactions/paid" 
-             data-path="dues_transactions" 
+             data-path="dues_transactions"
+             data-link="/admin/swag/"
              :columns="tableConfig">
   </datatable>
   <datatable v-else-if="this.tableFilter == 'pending'"
              id="swag-pending-table"
              data-url="/api/v1/dues/transactions/pendingSwag"
              data-path="dues_transactions"
+             data-link="/admin/swag/"
              :columns="tableConfig">
   </datatable>
 </template>
@@ -23,14 +25,7 @@ export default {
   data() {
     return {
       tableConfig: [
-        {
-          title: 'ID',
-          data: 'id',
-          render: function(data, type, row) {
-            var link = "<a href='/admin/swag/" + data + "'>" + data + '</a>';
-            return type === 'display' ? link : data;
-          },
-        },
+        { title: 'ID', data: 'id' },
         { title: 'Name', data: 'user.name' },
         { title: 'Dues Package', data: 'package.name' },
         { title: 'Shirt', data: 'swag_shirt_status' },

--- a/resources/assets/js/components/wrappers/UsersAdminTable.vue
+++ b/resources/assets/js/components/wrappers/UsersAdminTable.vue
@@ -11,14 +11,7 @@ export default {
   data() {
     return {
       tableConfig: [
-        {
-          title: 'GT Username',
-          data: 'uid',
-          render: function(data, type, row) {
-            var link = "<a href='/admin/users/" + data + "'>" + data + '</a>';
-            return type === 'display' ? link : data;
-          },
-        },
+        { title: 'GT Username', data: 'uid' },
         { title: 'GTID', data: 'gtid' },
         { title: 'First Name', data: 'first_name' },
         { title: 'Last Name', data: 'last_name' },


### PR DESCRIPTION
A check has been added to determine whether or not to use a default pathname. Now, Datatables.vue either defaults to window.location.pathname, or uses a prop passed in called data-link. This fixes broken links resulting from the previous branch. The hyperlinks in the ID column have been removed to simplify the codebase, and the "pointer" cursor is now applied when hovering over table rows.