### PR TITLE
Branded colors

### DIFF
--- a/resources/assets/sass/_custom.scss
+++ b/resources/assets/sass/_custom.scss
@@ -1,10 +1,7 @@
 // Copy variables from the
 
 //colors
-$brand-primary: #eeb211;
-
-//buttons
-$btn-primary-color: #111;
+$primary: #eeb211;
 
 //checkboxes
 $custom-control-checked-indicator-color: #111;
@@ -16,4 +13,4 @@ $enable-rounded: false;
 $font-family-sans-serif: 'Open Sans', sans-serif;
 
 // Form-Wizard Customization
-$default-color: $brand-primary;
+$default-color: $primary;

--- a/resources/assets/sass/_custom.scss
+++ b/resources/assets/sass/_custom.scss
@@ -1,7 +1,7 @@
 // Copy variables from the
 
 //colors
-$primary: #eeb211;
+$rj-gold: #eeb211;
 
 //checkboxes
 $custom-control-checked-indicator-color: #111;
@@ -13,4 +13,4 @@ $enable-rounded: false;
 $font-family-sans-serif: 'Open Sans', sans-serif;
 
 // Form-Wizard Customization
-$default-color: $primary;
+// $default-color: $primary;

--- a/resources/assets/sass/app.scss
+++ b/resources/assets/sass/app.scss
@@ -8,7 +8,7 @@
 @import 'node_modules/bootstrap/scss/bootstrap';
 
 .btn-primary {
-    @include button-variant($rj-gold, $rj-gold);
+  @include button-variant($rj-gold, $rj-gold);
 }
 
 // Custom Stylesheets

--- a/resources/assets/sass/app.scss
+++ b/resources/assets/sass/app.scss
@@ -7,5 +7,9 @@
 // Bootstrap
 @import 'node_modules/bootstrap/scss/bootstrap';
 
+.btn-primary {
+    @include button-variant($rj-gold, $rj-gold);
+}
+
 // Custom Stylesheets
 @import 'user';


### PR DESCRIPTION
See #342. This recolors the buttons to RJ gold.

<img width="202" alt="image" src="https://user-images.githubusercontent.com/291371/44750843-88d92e00-aae4-11e8-949d-1436c9b0a434.png">

The existing code would have under Bootstrap 3 changed all links to the gold as well, but there wasn't enough contrast on them in my opinion:

<img width="518" alt="image" src="https://user-images.githubusercontent.com/291371/44750813-74953100-aae4-11e8-9b2b-72a4db74524b.png">