### PR TITLE
Show the team in the attendance kiosk dialog

### DIFF
--- a/resources/assets/js/components/attendance/AttendanceKiosk.vue
+++ b/resources/assets/js/components/attendance/AttendanceKiosk.vue
@@ -123,6 +123,7 @@ export default {
       self.attendance.attendable_id = event.target.id;
       swal({
         title: 'Swipe your BuzzCard now',
+        html: event.target.innerText,
         showCancelButton: true,
         closeOnCancel: false,
         allowOutsideClick: true,


### PR DESCRIPTION
See #382. Here's what it looks like now:

<img width="529" alt="image" src="https://user-images.githubusercontent.com/291371/44754736-16bb1600-aaf1-11e8-9147-7eae1e9c4ffd.png">
