### PR TITLE
Fix self-serviceable column in teams admin table

### DIFF
--- a/resources/assets/js/components/wrappers/TeamsAdminTable.vue
+++ b/resources/assets/js/components/wrappers/TeamsAdminTable.vue
@@ -36,7 +36,7 @@ export default {
         },
         {
           title: 'Self-Serviceable',
-          data: 'self-serviceable',
+          data: 'self_serviceable',
           render: function(data, type, row) {
             return data === 1 ? 'Yes' : 'No';
           },


### PR DESCRIPTION
See #406. `self_serviceable` instead of `self-serviceable` in the datatable config