### PR TITLE
Add name to nova/logout route

### DIFF
--- a/routes/web.php
+++ b/routes/web.php
@@ -13,7 +13,7 @@
 
 Route::get('nova/logout', function () {
     return redirect('logout');
-});
+})->name('nova.logout');
 
 Route::group(['middleware' => 'auth.cas.force'], function () {
     Route::get('/', 'DashboardController@index')->name('home');


### PR DESCRIPTION
Nova was failing to load because it could not find the route named nova.logout. Routes can't have multiple names so this gives the name to the redirect. I'm open to better solutions; I couldn't find a more elegant fix.

Closes #451