### PR TITLE
Teams Tweaks

### DIFF
--- a/resources/assets/js/components/attendance/AttendanceKiosk.vue
+++ b/resources/assets/js/components/attendance/AttendanceKiosk.vue
@@ -43,7 +43,9 @@ export default {
           if (rawTeams.length < 1) {
             swal('Bueller...Bueller...', 'No teams found.', 'warning');
           } else {
-            this.teams = response.data.teams.sort(function(a, b) {
+            this.teams = response.data.teams.filter(function(item) {
+              return item.visible;
+            }).sort(function(a, b) {
               return a.name > b.name ? 1 : b.name > a.name ? -1 : 0;
             });
             this.startListening();

--- a/resources/assets/js/components/attendance/AttendanceKiosk.vue
+++ b/resources/assets/js/components/attendance/AttendanceKiosk.vue
@@ -44,7 +44,7 @@ export default {
             swal('Bueller...Bueller...', 'No teams found.', 'warning');
           } else {
             this.teams = response.data.teams.filter(function(item) {
-              return item.visible && item.attendable;
+              return item.attendable;
             }).sort(function(a, b) {
               return a.name > b.name ? 1 : b.name > a.name ? -1 : 0;
             });

--- a/resources/assets/js/components/attendance/AttendanceKiosk.vue
+++ b/resources/assets/js/components/attendance/AttendanceKiosk.vue
@@ -44,7 +44,7 @@ export default {
             swal('Bueller...Bueller...', 'No teams found.', 'warning');
           } else {
             this.teams = response.data.teams.filter(function(item) {
-              return item.attendable;
+              return item.visible && item.attendable;
             }).sort(function(a, b) {
               return a.name > b.name ? 1 : b.name > a.name ? -1 : 0;
             });

--- a/resources/assets/js/components/attendance/AttendanceKiosk.vue
+++ b/resources/assets/js/components/attendance/AttendanceKiosk.vue
@@ -44,7 +44,7 @@ export default {
             swal('Bueller...Bueller...', 'No teams found.', 'warning');
           } else {
             this.teams = response.data.teams.filter(function(item) {
-              return item.visible;
+              return item.visible && item.attendable;
             }).sort(function(a, b) {
               return a.name > b.name ? 1 : b.name > a.name ? -1 : 0;
             });

--- a/resources/assets/js/components/attendance/AttendanceManualAdd.vue
+++ b/resources/assets/js/components/attendance/AttendanceManualAdd.vue
@@ -96,7 +96,9 @@ export default {
           if (rawTeams.length < 1) {
             swal('Bueller...Bueller...', 'No teams found.', 'warning');
           } else {
-            let alphaTeams = response.data.teams.sort(function(a, b) {
+            let alphaTeams = response.data.teams.filter(function(item) {
+              return item.attendable;
+            }).sort(function(a, b) {
               return a.name > b.name ? 1 : b.name > a.name ? -1 : 0;
             });
             alphaTeams.forEach(function(team) {

--- a/resources/assets/js/components/teams/TeamEditForm.vue
+++ b/resources/assets/js/components/teams/TeamEditForm.vue
@@ -216,7 +216,8 @@ export default {
           this.hasError = false;
           this.feedback = 'Saved!';
           console.log('success');
-          window.location.href = '/admin/teams/' + response.data.team.slug;
+          var newHREF = '/admin/teams/' + response.data.team.slug;
+          if (!window.location.href.endsWith(newHREF)) window.location.href = newHREF;
         })
         .catch(response => {
           this.hasError = true;


### PR DESCRIPTION
Filter the kiosk to only show visible and attendable teams, filter the attendance admin page to only show attendable teams, and stop refreshing the team edit page every time it is submitted.