### PR TITLE
Prettier team attendance interface

### DIFF
--- a/resources/assets/js/components/attendance/AttendanceManualAdd.vue
+++ b/resources/assets/js/components/attendance/AttendanceManualAdd.vue
@@ -55,11 +55,14 @@
         </div>
         <div class="row form-row">
             <button type="button" class="btn btn-primary" @click="submit">Submit</button>
+            <button type="button" class="btn btn-primary mx-2" @click.prevent="setToToday" data-toggle="modal" data-target="#attendanceModal" :disabled="this.attendance.attendable_id.length == 0">Record Swipes</button>
         </div>
+        <attendance-modal id="attendanceModal" :attendableId="this.attendance.attendable_id" :attendableType="this.attendance.attendable_type"></attendance-modal>
     </div>
 </template>
 <script>
 import { required, numeric, between, minLength, maxLength } from 'vuelidate/lib/validators';
+import moment from 'moment';
 export default {
   name: 'attendance-manual-add',
   data() {
@@ -157,6 +160,10 @@ export default {
             );
           }
         });
+    },
+    setToToday() {
+      this.attendance.created_at = moment().format('YYYY-MM-DD');
+      this.attendance.gitd = '';
     },
   },
   mounted() {

--- a/resources/assets/js/components/attendance/AttendanceManualAdd.vue
+++ b/resources/assets/js/components/attendance/AttendanceManualAdd.vue
@@ -18,13 +18,11 @@
         <div class="row form-row">
             <label for="teams-buttons" class="col-sm-2 col-form-label">Team<span style="color:red">*</span></label>
             <div class="col-sm-10 col-lg-4">
-                <custom-radio-buttons
-                        v-model="attendance.attendable_id"
-                        :options="teams"
-                        id="teams-buttons"
-                        :is-error="$v.attendance.attendable_id.$error"
-                        @input="$v.attendance.attendable_id.$touch()">
-                </custom-radio-buttons>
+                <select id="teams-buttons" v-model="attendance.attendable_id" class="custom-select" :class="{ 'is-invalid': $v.attendance.attendable_id.$error }" @input="$v.attendance.attendable_id.$touch()">
+                    <option value="" style="display:none" v-if="!teams">Loading...</option>
+                    <option value="" style="display:none" v-if="teams && teams.length > 0">Select One</option>
+                    <option v-for="team in teams" :value="team.value">{{team.text}}</option>
+                </select>
                 <div class="invalid-feedback">
                     You must select a team.
                 </div>

--- a/resources/assets/js/components/attendance/AttendanceManualAdd.vue
+++ b/resources/assets/js/components/attendance/AttendanceManualAdd.vue
@@ -55,7 +55,9 @@
         </div>
         <div class="row form-row">
             <button type="button" class="btn btn-primary" @click="submit">Submit</button>
-            <button type="button" class="btn btn-primary mx-2" @click.prevent="setToToday" data-toggle="modal" data-target="#attendanceModal" :disabled="this.attendance.attendable_id.length == 0">Record Swipes</button>
+            <span class="d-inline-block" id="swipes-tooltip" tabindex="0" data-toggle="tooltip" title="Select a team">
+                <button type="button" class="btn btn-primary mx-2" @click.prevent="setToToday" data-toggle="modal" data-target="#attendanceModal" :disabled="!recordSwipesEnabled" :style="recordSwipesEnabled ? '' : 'pointer-events: none;'">Record Swipes</button>
+            </span>
         </div>
         <attendance-modal id="attendanceModal" :attendableId="this.attendance.attendable_id" :attendableType="this.attendance.attendable_type"></attendance-modal>
     </div>
@@ -86,7 +88,15 @@ export default {
       },
       attendanceBaseUrl: '/api/v1/attendance',
       teamsBaseUrl: '/api/v1/teams',
+      recordSwipesEnabled: false,
     };
+  },
+  watch: {
+    'attendance.attendable_id': function(val, oldVal) {
+      // Only enable the tooltip warning you to select a team when no team is selected
+      this.recordSwipesEnabled = typeof this.attendance.attendable_id === 'number';
+      $('#swipes-tooltip').tooltip(this.recordSwipesEnabled ? 'disable' : 'enable');
+    },
   },
   methods: {
     loadTeams() {
@@ -168,6 +178,7 @@ export default {
   },
   mounted() {
     this.loadTeams();
+    $('#swipes-tooltip').tooltip('enable');
   },
   validations: {
     attendance: {

--- a/resources/assets/js/components/wrappers/AttendanceModal.vue
+++ b/resources/assets/js/components/wrappers/AttendanceModal.vue
@@ -72,6 +72,10 @@ export default {
     'attendance.gtid': function(val, oldVal) {
       this.debouncedGTID();
     },
+    attendableId: function(val, oldVal) {
+      // Update the data object when the prop attendableId changes
+      this.attendance.attendable_id = this.attendableId;
+    }
   },
   created: function() {
     this.debouncedGTID = _.debounce(this.parseGTID, 500);

--- a/resources/views/attendance/admin.blade.php
+++ b/resources/views/attendance/admin.blade.php
@@ -20,7 +20,7 @@
     <div class="tab-content">
         <div class="tab-pane show active" id="update">
             <h3>Add</h3>
-            <em>Note:</em> This should be used for adding past attendance only. Normal team attendance should be recorded through the kiosk.<br/>
+            <em>Note:</em> This should only be used for adding past attendance and for teams that are not on the kiosk, such as trainings. Normal team attendance should be recorded through the kiosk.<br/>
             <attendance-manual-add></attendance-manual-add>
             <h3>Delete</h3>
             <div class="row">


### PR DESCRIPTION
As discussed in Slack, this is a nicer interface for team attendance that can accept raw BuzzCard swipes, particularly for trainings. The original interface still works as before, with just an additional button to get the modal.

Before selecting a team, there's a tooltip and the button is disabled:
<img width="979" alt="image" src="https://user-images.githubusercontent.com/291371/46185369-7ac72a80-c2a7-11e8-89ce-732abd948388.png">

The button brings up the same modal as the event admin page:
<img width="744" alt="image" src="https://user-images.githubusercontent.com/291371/46185382-8a467380-c2a7-11e8-86da-86df200ab0a8.png">
