### PR TITLE
Quiet warning about role "member" already being assigned to a user

### DIFF
--- a/app/Listeners/PaymentSuccessListener.php
+++ b/app/Listeners/PaymentSuccessListener.php
@@ -42,7 +42,7 @@ class PaymentSuccessListener
                 if ($role_member && ! $user->hasRole('member')) {
                     $user->assignRole($role_member);
                 } elseif ($user->hasRole('member')) {
-                    Log::warning(get_class().": Role 'member' already assigned to $user->uid");
+                    Log::notice(get_class().": Role 'member' already assigned to $user->uid");
                 } else {
                     Log::error(get_class().": Role 'member' not found for assignment to $user->uid");
                 }


### PR DESCRIPTION
Fix #454.

https://robojackets.slack.com/archives/C5Z5F8GVC/p1538323283000200