### PR TITLE
More retries and fixed sleep for Square API

### DIFF
--- a/app/Http/Controllers/PaymentController.php
+++ b/app/Http/Controllers/PaymentController.php
@@ -419,13 +419,13 @@ class PaymentController extends Controller
         //Query Square API to get authoritative data
         //See #284 for reasoning for loop
         $counter = 0;
-        while ($counter < 4) {
+        while ($counter < 10) {
             $square_txn = $this->getSquareTransaction($txnClient, $location, $server_txn_id);
             if (! $square_txn instanceof Exception) {
                 break;
             }
             $counter++;
-            sleep($counter * 0.1);
+            usleep($counter * 100000);
         }
 
         if ($square_txn instanceof Exception) {


### PR DESCRIPTION
Turns out `sleep()` only takes integer values so we weren't actually delaying by any meaningful amount.

I replaced it with `usleep()` which takes integer microseconds.

I also increased the number of retries so verification can take up to ~6 seconds before timing out.