### PR TITLE
Check for \SquareConnect\ApiException

### DIFF
--- a/app/Http/Controllers/PaymentController.php
+++ b/app/Http/Controllers/PaymentController.php
@@ -428,7 +428,7 @@ class PaymentController extends Controller
             usleep($counter * 100000);
         }
 
-        if ($square_txn instanceof Exception) {
+        if ($square_txn instanceof \SquareConnect\ApiException) {
             Bugsnag::notifyException($square_txn);
 
             return response(view(


### PR DESCRIPTION
Based on following log entry

```
[2018-10-02 11:08:29] production.ERROR: Call to undefined method SquareConnect\ApiException::getTransaction() {"userId":"azhou48","exception":"[object] (Symfony\\Component\\Debug\\Exception\\FatalThrowableError(code: 0): Call to undefined method SquareConnect\\ApiException::getTransaction() at /var/www/apiary/production/app/Http/Controllers/PaymentController.php:443)
```