### PR TITLE
Sync OrgSync teams on login

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -41,6 +41,7 @@ CAS_MASQUERADE_gtGTID=
 CAS_MASQUERADE_email_primary=
 CAS_MASQUERADE_givenName=
 CAS_MASQUERADE_sn=
+CAS_MASQUERADE_gtPersonEntitlement=/gt/departmental/studentlife/studentgroups/RoboJackets/BattleBots,/gt/departmental/studentlife/studentgroups/RoboJackets/Officers,/gt/departmental/studentlife/studentgroups/RoboJackets/Core
 
 GA_UA=UA-XXXXX-Y
 

--- a/app/Traits/CreateOrUpdateCASUser.php
+++ b/app/Traits/CreateOrUpdateCASUser.php
@@ -25,10 +25,18 @@ trait CreateOrUpdateCASUser
     public function createOrUpdateCASUser(Request $request)
     {
         $attrs = ['gtGTID', 'email_primary', 'givenName', 'sn'];
+        // Attributes that will be split by commas when masquerading
+        $arrayAttrs = ['gtPersonEntitlement'];
+        // Merge them together so we verify all attributes are present, even the array ones
+        $attrs = array_merge($attrs, $arrayAttrs);
         if ($this->cas->isMasquerading()) {
             $masq_attrs = [];
             foreach ($attrs as $attr) {
                 $masq_attrs[$attr] = config('cas.cas_masquerade_'.$attr);
+            }
+            // Split the attributes that we need to split
+            foreach ($arrayAttrs as $attr) {
+                $masq_attrs[$attr] = explode(',', $masq_attrs[$attr]);
             }
             $this->cas->setAttributes($masq_attrs);
         }

--- a/app/Traits/CreateOrUpdateCASUser.php
+++ b/app/Traits/CreateOrUpdateCASUser.php
@@ -9,8 +9,8 @@
 namespace App\Traits;
 
 use Log;
-use App\User;
 use App\Team;
+use App\User;
 use Illuminate\Http\Request;
 use Spatie\Permission\Models\Role;
 
@@ -90,10 +90,10 @@ trait CreateOrUpdateCASUser
 
         if ($user->teams->count() == 0) {
             Log::info(get_class().": Updating team membership for $user->uid from OrgSync.");
-            $orgsyncGroups = array();
+            $orgsyncGroups = [];
             foreach ($this->cas->getAttribute('gtPersonEntitlement') as $entitlement) {
                 if (strpos($entitlement, '/gt/departmental/studentlife/studentgroups/RoboJackets/') === 0) {
-                    $orgsyncGroups[]  = substr($entitlement, 55);
+                    $orgsyncGroups[] = substr($entitlement, 55);
                 }
             }
 

--- a/config/cas.php
+++ b/config/cas.php
@@ -162,4 +162,5 @@ return [
     'cas_masquerade_email_primary' => env('CAS_MASQUERADE_email_primary', null),
     'cas_masquerade_givenName' => env('CAS_MASQUERADE_givenName', null),
     'cas_masquerade_sn' => env('CAS_MASQUERADE_sn', null),
+    'cas_masquerade_gtPersonEntitlement' => env('CAS_MASQUERADE_gtPersonEntitlement', null),
 ];


### PR DESCRIPTION
On login, if the user isn't a member of any teams, make them a member of teams matching their OrgSync teams.

Fixes #494.