### PR TITLE
Quiet logging for Orgsync teams sync

### DIFF
--- a/app/Traits/CreateOrUpdateCASUser.php
+++ b/app/Traits/CreateOrUpdateCASUser.php
@@ -89,7 +89,6 @@ trait CreateOrUpdateCASUser
         }
 
         if ($user->teams->count() == 0) {
-            Log::info(get_class().": Updating team membership for $user->uid from OrgSync.");
             $orgsyncGroups = [];
             foreach ($this->cas->getAttribute('gtPersonEntitlement') as $entitlement) {
                 if (strpos($entitlement, '/gt/departmental/studentlife/studentgroups/RoboJackets/') === 0) {
@@ -97,11 +96,16 @@ trait CreateOrUpdateCASUser
                 }
             }
 
+            $addedAnyTeams = FALSE;
             foreach ($orgsyncGroups as $group) {
                 $team = Team::where('name', $group)->first();
                 if ($team != null) {
                     $team->members()->syncWithoutDetaching($user);
+                    $addedAnyTeams = TRUE;
                 }
+            }
+            if ($addedAnyTeams) {
+                Log::info(get_class().": Updating team membership for $user->uid from OrgSync.");
             }
         }
 

--- a/app/Traits/CreateOrUpdateCASUser.php
+++ b/app/Traits/CreateOrUpdateCASUser.php
@@ -96,12 +96,12 @@ trait CreateOrUpdateCASUser
                 }
             }
 
-            $addedAnyTeams = FALSE;
+            $addedAnyTeams = false;
             foreach ($orgsyncGroups as $group) {
                 $team = Team::where('name', $group)->first();
                 if ($team != null) {
                     $team->members()->syncWithoutDetaching($user);
-                    $addedAnyTeams = TRUE;
+                    $addedAnyTeams = true;
                 }
             }
             if ($addedAnyTeams) {


### PR DESCRIPTION
This will only log if a user is added to a team. Before, it would log on every request for users with no teams in OrgSync that matched Apiary.