### PR TITLE
Add more Nova resources

### DIFF
--- a/app/Attendance.php
+++ b/app/Attendance.php
@@ -36,6 +36,14 @@ class Attendance extends Model
     }
 
     /**
+     * Get the User who recorded the Attendance model.
+     */
+    public function recorded()
+    {
+        return $this->hasOne('\App\User', 'id', 'recorded_by');
+    }
+
+    /**
      * Scope query to start at given date.
      *
      * @param $query mixed

--- a/app/Nova/Attendance.php
+++ b/app/Nova/Attendance.php
@@ -3,16 +3,11 @@
 namespace App\Nova;
 
 use Laravel\Nova\Panel;
-use Laravel\Nova\Fields\ID;
 use Illuminate\Http\Request;
 use Laravel\Nova\Fields\Text;
-use Laravel\Nova\Fields\BelongsTo;
-use Laravel\Nova\Fields\Boolean;
-use Laravel\Nova\Fields\HasMany;
-use Laravel\Nova\Fields\DateTime;
-use Laravel\Nova\Fields\Textarea;
-use Laravel\Nova\Fields\Currency;
 use Laravel\Nova\Fields\MorphTo;
+use Laravel\Nova\Fields\DateTime;
+use Laravel\Nova\Fields\BelongsTo;
 
 class Attendance extends Resource
 {

--- a/app/Nova/Attendance.php
+++ b/app/Nova/Attendance.php
@@ -1,0 +1,162 @@
+<?php
+
+namespace App\Nova;
+
+use Laravel\Nova\Panel;
+use Laravel\Nova\Fields\ID;
+use Illuminate\Http\Request;
+use Laravel\Nova\Fields\Text;
+use Laravel\Nova\Fields\BelongsTo;
+use Laravel\Nova\Fields\Boolean;
+use Laravel\Nova\Fields\HasMany;
+use Laravel\Nova\Fields\DateTime;
+use Laravel\Nova\Fields\Textarea;
+use Laravel\Nova\Fields\Currency;
+use Laravel\Nova\Fields\MorphTo;
+
+class Attendance extends Resource
+{
+    /**
+     * The model the resource corresponds to.
+     *
+     * @var string
+     */
+    public static $model = 'App\Attendance';
+
+    /**
+     * Get the displayble label of the resource.
+     *
+     * @return string
+     */
+    public static function label()
+    {
+        return 'Attendance';
+    }
+
+    /**
+     * Get the displayble singular label of the resource.
+     *
+     * @return string
+     */
+    public static function singularLabel()
+    {
+        return 'Attendance Record';
+    }
+
+    /**
+     * Get the URI key for the resource.
+     *
+     * @return string
+     */
+    public static function uriKey()
+    {
+        return 'attendance';
+    }
+
+    /**
+     * The single value that should be used to represent the resource when being displayed.
+     *
+     * @var string
+     */
+    public static $title = 'name';
+
+    /**
+     * Get the fields displayed by the resource.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return array
+     */
+    public function fields(Request $request)
+    {
+        return [
+            new Panel('Basic Information', $this->basicFields()),
+
+            new Panel('Metadata', $this->metaFields()),
+        ];
+    }
+
+    protected function basicFields()
+    {
+        return [
+            Text::make('GTID')
+                ->sortable()
+                ->rules('required', 'max:255'),
+
+            (new BelongsTo('User', 'attendee', 'App\Nova\User'))
+                ->sortable(),
+
+            (new MorphTo('Attended', 'attendable'))
+                ->sortable()
+                ->types([
+                    Event::class,
+                    Team::class,
+                ]),
+
+            (new BelongsTo('Recorded By', 'recorded', 'App\Nova\User'))
+                ->sortable()
+                ->help('The user that recorded the swipe'),
+
+            DateTime::make('Time', 'created_at')
+                ->sortable(),
+
+            Text::make('Source')
+                ->hideFromIndex()
+                ->sortable(),
+        ];
+    }
+
+    protected function metaFields()
+    {
+        return [
+            DateTime::make('Created', 'created_at')
+                ->onlyOnDetail(),
+
+            DateTime::make('Last Updated', 'updated_at')
+                ->onlyOnDetail(),
+        ];
+    }
+
+    /**
+     * Get the cards available for the request.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return array
+     */
+    public function cards(Request $request)
+    {
+        return [];
+    }
+
+    /**
+     * Get the filters available for the resource.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return array
+     */
+    public function filters(Request $request)
+    {
+        return [];
+    }
+
+    /**
+     * Get the lenses available for the resource.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return array
+     */
+    public function lenses(Request $request)
+    {
+        return [];
+    }
+
+    /**
+     * Get the actions available for the resource.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return array
+     */
+    public function actions(Request $request)
+    {
+        return [];
+    }
+}

--- a/app/Nova/Attendance.php
+++ b/app/Nova/Attendance.php
@@ -77,10 +77,10 @@ class Attendance extends Resource
                 ->sortable()
                 ->rules('required', 'max:255'),
 
-            (new BelongsTo('User', 'attendee', 'App\Nova\User'))
+            BelongsTo::make('User', 'attendee')
                 ->sortable(),
 
-            (new MorphTo('Attended', 'attendable'))
+            MorphTo::make('Attended', 'attendable')
                 ->sortable()
                 ->types([
                     Event::class,

--- a/app/Nova/Event.php
+++ b/app/Nova/Event.php
@@ -1,0 +1,147 @@
+<?php
+
+namespace App\Nova;
+
+use Laravel\Nova\Panel;
+use Laravel\Nova\Fields\ID;
+use Illuminate\Http\Request;
+use Laravel\Nova\Fields\Text;
+use Laravel\Nova\Fields\BelongsTo;
+use Laravel\Nova\Fields\Boolean;
+use Laravel\Nova\Fields\HasMany;
+use Laravel\Nova\Fields\DateTime;
+use Laravel\Nova\Fields\Textarea;
+use Laravel\Nova\Fields\Currency;
+
+class Event extends Resource
+{
+    /**
+     * The model the resource corresponds to.
+     *
+     * @var string
+     */
+    public static $model = 'App\Event';
+
+    /**
+     * The single value that should be used to represent the resource when being displayed.
+     *
+     * @var string
+     */
+    public static $title = 'name';
+
+    /**
+     * The columns that should be searched.
+     *
+     * @var array
+     */
+    public static $search = [
+        'name',
+    ];
+
+    /**
+     * Get the fields displayed by the resource.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return array
+     */
+    public function fields(Request $request)
+    {
+        return [
+            new Panel('Basic Information', $this->basicFields()),
+
+            new Panel('Metadata', $this->metaFields()),
+
+            HasMany::make('RSVPs'),
+
+            HasMany::make('Attendance'),
+        ];
+    }
+
+    protected function basicFields()
+    {
+        return [
+            Text::make('Event Name', 'name')
+                ->sortable()
+                ->rules('required', 'max:255'),
+
+            (new BelongsTo('Organizer', 'organizer', 'App\Nova\User'))
+                ->searchable()
+                ->sortable()
+                ->rules('required')
+                // default to self
+                ->help('The organizer of the event'),
+
+            DateTime::make('Start Time')
+                ->hideFromIndex(),
+
+            DateTime::make('End Time')
+                ->hideFromIndex(),
+
+            Text::make('Location')
+                ->hideFromIndex()
+                ->rules('max:255'),
+
+            Currency::make('Cost')
+                ->hideFromIndex()
+                ->rules('required'),
+
+            Boolean::make('Anonymous RSVP', 'allow_anonymous_rsvp')
+                ->hideFromIndex(),
+        ];
+    }
+
+    protected function metaFields()
+    {
+        return [
+            DateTime::make('Created', 'created_at')
+                ->onlyOnDetail(),
+
+            DateTime::make('Last Updated', 'updated_at')
+                ->onlyOnDetail(),
+        ];
+    }
+
+    /**
+     * Get the cards available for the request.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return array
+     */
+    public function cards(Request $request)
+    {
+        return [];
+    }
+
+    /**
+     * Get the filters available for the resource.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return array
+     */
+    public function filters(Request $request)
+    {
+        return [];
+    }
+
+    /**
+     * Get the lenses available for the resource.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return array
+     */
+    public function lenses(Request $request)
+    {
+        return [];
+    }
+
+    /**
+     * Get the actions available for the resource.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return array
+     */
+    public function actions(Request $request)
+    {
+        return [];
+    }
+}

--- a/app/Nova/Event.php
+++ b/app/Nova/Event.php
@@ -3,15 +3,13 @@
 namespace App\Nova;
 
 use Laravel\Nova\Panel;
-use Laravel\Nova\Fields\ID;
 use Illuminate\Http\Request;
 use Laravel\Nova\Fields\Text;
-use Laravel\Nova\Fields\BelongsTo;
 use Laravel\Nova\Fields\Boolean;
 use Laravel\Nova\Fields\HasMany;
-use Laravel\Nova\Fields\DateTime;
-use Laravel\Nova\Fields\Textarea;
 use Laravel\Nova\Fields\Currency;
+use Laravel\Nova\Fields\DateTime;
+use Laravel\Nova\Fields\BelongsTo;
 
 class Event extends Resource
 {

--- a/app/Nova/Rsvp.php
+++ b/app/Nova/Rsvp.php
@@ -3,16 +3,10 @@
 namespace App\Nova;
 
 use Laravel\Nova\Panel;
-use Laravel\Nova\Fields\ID;
 use Illuminate\Http\Request;
 use Laravel\Nova\Fields\Text;
-use Laravel\Nova\Fields\BelongsTo;
-use Laravel\Nova\Fields\Boolean;
-use Laravel\Nova\Fields\HasMany;
 use Laravel\Nova\Fields\DateTime;
-use Laravel\Nova\Fields\Textarea;
-use Laravel\Nova\Fields\Currency;
-use Laravel\Nova\Fields\MorphTo;
+use Laravel\Nova\Fields\BelongsTo;
 
 class Rsvp extends Resource
 {

--- a/app/Nova/Rsvp.php
+++ b/app/Nova/Rsvp.php
@@ -1,0 +1,162 @@
+<?php
+
+namespace App\Nova;
+
+use Laravel\Nova\Panel;
+use Laravel\Nova\Fields\ID;
+use Illuminate\Http\Request;
+use Laravel\Nova\Fields\Text;
+use Laravel\Nova\Fields\BelongsTo;
+use Laravel\Nova\Fields\Boolean;
+use Laravel\Nova\Fields\HasMany;
+use Laravel\Nova\Fields\DateTime;
+use Laravel\Nova\Fields\Textarea;
+use Laravel\Nova\Fields\Currency;
+use Laravel\Nova\Fields\MorphTo;
+
+class Rsvp extends Resource
+{
+    /**
+     * The model the resource corresponds to.
+     *
+     * @var string
+     */
+    public static $model = 'App\Rsvp';
+
+    /**
+     * Get the displayble label of the resource.
+     *
+     * @return string
+     */
+    public static function label()
+    {
+        return 'RSVPs';
+    }
+
+    /**
+     * Get the displayble singular label of the resource.
+     *
+     * @return string
+     */
+    public static function singularLabel()
+    {
+        return 'RSVP';
+    }
+
+    /**
+     * The single value that should be used to represent the resource when being displayed.
+     *
+     * @var string
+     */
+    public static $title = 'name';
+
+    /**
+     * Indicates if the resource should be displayed in the sidebar.
+     *
+     * @var bool
+     */
+    public static $displayInNavigation = false;
+
+    /**
+     * Get the fields displayed by the resource.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return array
+     */
+    public function fields(Request $request)
+    {
+        return [
+            new Panel('Basic Information', $this->basicFields()),
+
+            new Panel('Detailed Information', $this->detailedFields()),
+
+            new Panel('Metadata', $this->metaFields()),
+        ];
+    }
+
+    protected function basicFields()
+    {
+        return [
+            BelongsTo::make('User')
+                ->sortable(),
+
+            BelongsTo::make('Event')
+                ->sortable(),
+
+            Text::make('Response')
+                ->sortable(),
+
+            Text::make('Source')
+                ->sortable(),
+        ];
+    }
+
+    protected function detailedFields()
+    {
+        return [
+            Text::make('User Agent')
+                ->hideFromIndex(),
+
+            Text::make('IP Address')
+                ->hideFromIndex(),
+
+            Text::make('Token')
+                ->hideFromIndex(),
+        ];
+    }
+
+    protected function metaFields()
+    {
+        return [
+            DateTime::make('Created', 'created_at')
+                ->onlyOnDetail(),
+
+            DateTime::make('Last Updated', 'updated_at')
+                ->onlyOnDetail(),
+        ];
+    }
+
+    /**
+     * Get the cards available for the request.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return array
+     */
+    public function cards(Request $request)
+    {
+        return [];
+    }
+
+    /**
+     * Get the filters available for the resource.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return array
+     */
+    public function filters(Request $request)
+    {
+        return [];
+    }
+
+    /**
+     * Get the lenses available for the resource.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return array
+     */
+    public function lenses(Request $request)
+    {
+        return [];
+    }
+
+    /**
+     * Get the actions available for the resource.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return array
+     */
+    public function actions(Request $request)
+    {
+        return [];
+    }
+}

--- a/app/Nova/Team.php
+++ b/app/Nova/Team.php
@@ -56,7 +56,7 @@ class Team extends Resource
 
             HasMany::make('User', 'members'),
 
-			HasMany::make('Attendance'),
+            HasMany::make('Attendance'),
         ];
     }
 

--- a/app/Nova/Team.php
+++ b/app/Nova/Team.php
@@ -55,6 +55,8 @@ class Team extends Resource
             new Panel('Metadata', $this->metaFields()),
 
             HasMany::make('User', 'members'),
+
+			HasMany::make('Attendance'),
         ];
     }
 

--- a/app/Nova/User.php
+++ b/app/Nova/User.php
@@ -8,10 +8,10 @@ use Laravel\Nova\Fields\Text;
 use Laravel\Nova\Fields\Number;
 use Laravel\Nova\Fields\Select;
 use Laravel\Nova\Fields\Boolean;
+use Laravel\Nova\Fields\HasMany;
 use Laravel\Nova\Fields\DateTime;
 use Laravel\Nova\Fields\MorphToMany;
 use Laravel\Nova\Fields\BelongsToMany;
-use Laravel\Nova\Fields\HasMany;
 
 class User extends Resource
 {
@@ -59,7 +59,7 @@ class User extends Resource
 
             BelongsToMany::make('Teams'),
 
-			HasMany::make('Attendance'),
+            HasMany::make('Attendance'),
 
             new Panel('Metadata', $this->metaFields()),
         ];

--- a/app/Nova/User.php
+++ b/app/Nova/User.php
@@ -11,6 +11,7 @@ use Laravel\Nova\Fields\Boolean;
 use Laravel\Nova\Fields\DateTime;
 use Laravel\Nova\Fields\MorphToMany;
 use Laravel\Nova\Fields\BelongsToMany;
+use Laravel\Nova\Fields\HasMany;
 
 class User extends Resource
 {
@@ -57,6 +58,8 @@ class User extends Resource
             new Panel('Swag', $this->swagFields()),
 
             BelongsToMany::make('Teams'),
+
+			HasMany::make('Attendance'),
 
             new Panel('Metadata', $this->metaFields()),
         ];

--- a/app/Policies/AttendancePolicy.php
+++ b/app/Policies/AttendancePolicy.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace App\Policies;
+
+use App\User;
+use App\Attendance;
+use Illuminate\Auth\Access\HandlesAuthorization;
+
+class AttendancePolicy
+{
+    use HandlesAuthorization;
+
+    /**
+     * Determine whether the user can view the attendance.
+     *
+     * @param  \App\User  $user
+     * @param  \App\Attendance  $attendance
+     * @return mixed
+     */
+    public function view(User $user, Attendance $attendance)
+    {
+        return $user->can('read-attendance');
+    }
+
+    /**
+     * Determine whether the user can create attendances.
+     *
+     * @param  \App\User  $user
+     * @return mixed
+     */
+    public function create(User $user)
+    {
+        // Attendance should be created in the old admin interface for now.
+        return false;
+    }
+
+    /**
+     * Determine whether the user can update the attendance.
+     *
+     * @param  \App\User  $user
+     * @param  \App\Attendance  $attendance
+     * @return mixed
+     */
+    public function update(User $user, Attendance $attendance)
+    {
+        return false;
+    }
+
+    /**
+     * Determine whether the user can delete the attendance.
+     *
+     * @param  \App\User  $user
+     * @param  \App\Attendance  $attendance
+     * @return mixed
+     */
+    public function delete(User $user, Attendance $attendance)
+    {
+        return $user->can('delete-attendance');
+    }
+
+    /**
+     * Determine whether the user can restore the attendance.
+     *
+     * @param  \App\User  $user
+     * @param  \App\Attendance  $attendance
+     * @return mixed
+     */
+    public function restore(User $user, Attendance $attendance)
+    {
+        return false;
+    }
+
+    /**
+     * Determine whether the user can permanently delete the attendance.
+     *
+     * @param  \App\User  $user
+     * @param  \App\Attendance  $attendance
+     * @return mixed
+     */
+    public function forceDelete(User $user, Attendance $attendance)
+    {
+        return false;
+    }
+}

--- a/app/Policies/RsvpPolicy.php
+++ b/app/Policies/RsvpPolicy.php
@@ -2,8 +2,8 @@
 
 namespace App\Policies;
 
-use App\User;
 use App\Rsvp;
+use App\User;
 use Illuminate\Auth\Access\HandlesAuthorization;
 
 class RsvpPolicy

--- a/app/Policies/RsvpPolicy.php
+++ b/app/Policies/RsvpPolicy.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace App\Policies;
+
+use App\User;
+use App\Rsvp;
+use Illuminate\Auth\Access\HandlesAuthorization;
+
+class RsvpPolicy
+{
+    use HandlesAuthorization;
+
+    /**
+     * Determine whether the user can view the rsvp.
+     *
+     * @param  \App\User  $user
+     * @param  \App\Rsvp  $rsvp
+     * @return mixed
+     */
+    public function view(User $user, Rsvp $rsvp)
+    {
+        return $user->can('read-rsvps');
+    }
+
+    /**
+     * Determine whether the user can create rsvps.
+     *
+     * @param  \App\User  $user
+     * @return mixed
+     */
+    public function create(User $user)
+    {
+        return false;
+    }
+
+    /**
+     * Determine whether the user can update the rsvp.
+     *
+     * @param  \App\User  $user
+     * @param  \App\Rsvp  $rsvp
+     * @return mixed
+     */
+    public function update(User $user, Rsvp $rsvp)
+    {
+        return false;
+    }
+
+    /**
+     * Determine whether the user can delete the rsvp.
+     *
+     * @param  \App\User  $user
+     * @param  \App\Rsvp  $rsvp
+     * @return mixed
+     */
+    public function delete(User $user, Rsvp $rsvp)
+    {
+        return $user->can('delete-rsvps');
+    }
+
+    /**
+     * Determine whether the user can restore the rsvp.
+     *
+     * @param  \App\User  $user
+     * @param  \App\Rsvp  $rsvp
+     * @return mixed
+     */
+    public function restore(User $user, Rsvp $rsvp)
+    {
+        return false;
+    }
+
+    /**
+     * Determine whether the user can permanently delete the rsvp.
+     *
+     * @param  \App\User  $user
+     * @param  \App\Rsvp  $rsvp
+     * @return mixed
+     */
+    public function forceDelete(User $user, Rsvp $rsvp)
+    {
+        return false;
+    }
+}

--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Providers;
+
+use App\Attendance;
+use App\Policies\AttendancePolicy;
+use Illuminate\Support\Facades\Gate;
+use Illuminate\Foundation\Support\Providers\AuthServiceProvider as ServiceProvider;
+
+class AuthServiceProvider extends ServiceProvider
+{
+    /**
+     * The policy mappings for the application.
+     *
+     * @var array
+     */
+    protected $policies = [
+        Attendance::class => AttendancePolicy::class,
+    ];
+
+    /**
+     * Register any application authentication / authorization services.
+     *
+     * @return void
+     */
+    public function boot()
+    {
+        $this->registerPolicies();
+    }
+}

--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -2,11 +2,10 @@
 
 namespace App\Providers;
 
-use App\Attendance;
 use App\Rsvp;
-use App\Policies\AttendancePolicy;
+use App\Attendance;
 use App\Policies\RsvpPolicy;
-use Illuminate\Support\Facades\Gate;
+use App\Policies\AttendancePolicy;
 use Illuminate\Foundation\Support\Providers\AuthServiceProvider as ServiceProvider;
 
 class AuthServiceProvider extends ServiceProvider

--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -3,7 +3,9 @@
 namespace App\Providers;
 
 use App\Attendance;
+use App\Rsvp;
 use App\Policies\AttendancePolicy;
+use App\Policies\RsvpPolicy;
 use Illuminate\Support\Facades\Gate;
 use Illuminate\Foundation\Support\Providers\AuthServiceProvider as ServiceProvider;
 
@@ -16,6 +18,7 @@ class AuthServiceProvider extends ServiceProvider
      */
     protected $policies = [
         Attendance::class => AttendancePolicy::class,
+        Rsvp::class => RsvpPolicy::class,
     ];
 
     /**

--- a/app/User.php
+++ b/app/User.php
@@ -76,6 +76,14 @@ class User extends Authenticatable
     }
 
     /**
+     *  Get the attendance records associated with this user.
+     */
+    public function attendance()
+    {
+        return $this->hasMany(\App\Attendance::class, 'gtid', 'gtid');
+    }
+
+    /**
      *  Get the Teams that this User is a member of.
      */
     public function teams()

--- a/config/app.php
+++ b/config/app.php
@@ -169,6 +169,7 @@ return [
         /*
          * Application Service Providers...
          */
+        App\Providers\AuthServiceProvider::class,
         App\Providers\AppServiceProvider::class,
         // App\Providers\BroadcastServiceProvider::class,
         App\Providers\EventServiceProvider::class,


### PR DESCRIPTION
Fixes #474, fixes #473. Starts #434 (only has policies for attendance and RSVPs).

Attendance resource page:
<img width="1266" alt="screen shot 2018-10-10 at 5 10 14 pm" src="https://user-images.githubusercontent.com/291371/46766349-bef6f980-ccaf-11e8-9324-9bc451e83dfe.png">

Events resource page:
<img width="1012" alt="image" src="https://user-images.githubusercontent.com/291371/46766397-e352d600-ccaf-11e8-9ada-565074aef942.png">

Event detail page has RSVPs and attendance:
<img width="1007" alt="image" src="https://user-images.githubusercontent.com/291371/46766616-7855cf00-ccb0-11e8-8a12-2ed7906598a6.png">

RSVP detail page: (not linked in the sidebar, only from events)
<img width="957" alt="image" src="https://user-images.githubusercontent.com/291371/46766691-ba7f1080-ccb0-11e8-9929-8fc4c08ba940.png">

Teams and user pages also have attendance on them. Attendance and RSVPs can't be created or edited in Nova.