### PR TITLE
Fix is_active attribute

### DIFF
--- a/app/User.php
+++ b/app/User.php
@@ -208,20 +208,7 @@ class User extends Authenticatable
      */
     public function getIsActiveAttribute()
     {
-        if ($this->dues->count() > 0) {
-            $lastDuesTransaction = $this->dues->last();
-            $pkgIsActive = $lastDuesTransaction->package->is_active;
-            $hasPayment = ($lastDuesTransaction->payment()->exists());
-            if ($hasPayment) {
-                $paidTotal = ($lastDuesTransaction->payment->sum('amount') >= $lastDuesTransaction->getPayableAmount());
-
-                return $paidTotal && $pkgIsActive;
-            } else {
-                return false;
-            }
-        } else {
-            return false;
-        }
+        return User::where('id', $this->id)->active()->count() != 0;
     }
 
     /**

--- a/app/User.php
+++ b/app/User.php
@@ -208,7 +208,7 @@ class User extends Authenticatable
      */
     public function getIsActiveAttribute()
     {
-        return User::where('id', $this->id)->active()->count() != 0;
+        return self::where('id', $this->id)->active()->count() != 0;
     }
 
     /**


### PR DESCRIPTION
It was only looking at the most recent dues package, but that's not necessarily the one that got paid (though it should be). This was an issue in test where scopeActive and is_active were not always the same. Now is_active uses the scope.