### PR TITLE
Add missing perms to non-members

### DIFF
--- a/database/migrations/2018_10_11_152147_add_hidden_teams_permission_to_non_member.php
+++ b/database/migrations/2018_10_11_152147_add_hidden_teams_permission_to_non_member.php
@@ -1,0 +1,40 @@
+<?php
+
+use Spatie\Permission\Models\Role;
+use Spatie\Permission\Models\Permission;
+use Illuminate\Database\Migrations\Migration;
+
+class AddHiddenTeamsPermissionToNonMember extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        // Reset cached roles and permissions
+        app()['cache']->forget('spat5ie.permission.cache');
+
+        Permission::firstOrCreate(['name' => 'update-teams-membership-own']);
+
+        $role = Role::firstOrCreate(['name' => 'non-member']);
+        $role->givePermissionTo('update-teams-membership-own');
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        // Reset cached roles and permissions
+        app()['cache']->forget('spatie.permission.cache');
+
+        $role = Role::firstOrCreate(['name' => 'non-member']);
+        $role->revokePermissionTo('update-teams-membership-own');
+
+        Permission::where('name', 'update-teams-membership-own')->delete();
+    }
+}

--- a/database/migrations/2018_10_11_152147_add_hidden_teams_permission_to_non_member.php
+++ b/database/migrations/2018_10_11_152147_add_hidden_teams_permission_to_non_member.php
@@ -14,7 +14,7 @@ class AddHiddenTeamsPermissionToNonMember extends Migration
     public function up()
     {
         // Reset cached roles and permissions
-        app()['cache']->forget('spat5ie.permission.cache');
+        app()['cache']->forget('spatie.permission.cache');
 
         Permission::firstOrCreate(['name' => 'update-teams-membership-own']);
 
@@ -34,7 +34,6 @@ class AddHiddenTeamsPermissionToNonMember extends Migration
 
         $role = Role::firstOrCreate(['name' => 'non-member']);
         $role->revokePermissionTo('update-teams-membership-own');
-
         Permission::where('name', 'update-teams-membership-own')->delete();
     }
 }


### PR DESCRIPTION
Fixes #499 

The issue is that the `update-teams-membership-own` permission (required for the `updateMembers` route) is never added to the `non-member` role.