### PR TITLE
Add reports

### DIFF
--- a/app/Nova/Actions/ExportGtid.php
+++ b/app/Nova/Actions/ExportGtid.php
@@ -2,12 +2,7 @@
 
 namespace App\Nova\Actions;
 
-use Illuminate\Bus\Queueable;
 use Laravel\Nova\Actions\Action;
-use Illuminate\Support\Collection;
-use Laravel\Nova\Fields\ActionFields;
-use Illuminate\Queue\SerializesModels;
-use Illuminate\Queue\InteractsWithQueue;
 use Maatwebsite\LaravelNovaExcel\Actions\DownloadExcel;
 
 class ExportGtid extends DownloadExcel
@@ -26,7 +21,8 @@ class ExportGtid extends DownloadExcel
      */
     public $availableForEntireResource = true;
 
-    public function __construct() {
+    public function __construct()
+    {
         $this->withFilename('Members.csv')
             ->withWriterType(\Maatwebsite\Excel\Excel::CSV)
             ->only('gtid');

--- a/app/Nova/Actions/ExportGtid.php
+++ b/app/Nova/Actions/ExportGtid.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Nova\Actions;
+
+use Illuminate\Bus\Queueable;
+use Laravel\Nova\Actions\Action;
+use Illuminate\Support\Collection;
+use Laravel\Nova\Fields\ActionFields;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Queue\InteractsWithQueue;
+use Maatwebsite\LaravelNovaExcel\Actions\DownloadExcel;
+
+class ExportGtid extends DownloadExcel
+{
+    /**
+     * The displayable name of the action.
+     *
+     * @var string
+     */
+    public $name = 'Export GTIDs';
+
+    /**
+     * Indicates if this action is available to run against the entire resource.
+     *
+     * @var bool
+     */
+    public $availableForEntireResource = true;
+
+    public function __construct() {
+        $this->withFilename('Members.csv')
+            ->withWriterType(\Maatwebsite\Excel\Excel::CSV)
+            ->only('gtid');
+    }
+}

--- a/app/Nova/Actions/ExportUsername.php
+++ b/app/Nova/Actions/ExportUsername.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Nova\Actions;
+
+use Illuminate\Bus\Queueable;
+use Laravel\Nova\Actions\Action;
+use Illuminate\Support\Collection;
+use Laravel\Nova\Fields\ActionFields;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Queue\InteractsWithQueue;
+use Maatwebsite\LaravelNovaExcel\Actions\DownloadExcel;
+
+class ExportUsername extends DownloadExcel
+{
+    /**
+     * The displayable name of the action.
+     *
+     * @var string
+     */
+    public $name = 'Export Usernames';
+
+    /**
+     * Indicates if this action is available to run against the entire resource.
+     *
+     * @var bool
+     */
+    public $availableForEntireResource = true;
+
+    public function __construct() {
+        $this->withFilename('Members.csv')
+            ->withWriterType(\Maatwebsite\Excel\Excel::CSV)
+            ->only('uid');
+    }
+}

--- a/app/Nova/Actions/ExportUsername.php
+++ b/app/Nova/Actions/ExportUsername.php
@@ -2,12 +2,7 @@
 
 namespace App\Nova\Actions;
 
-use Illuminate\Bus\Queueable;
 use Laravel\Nova\Actions\Action;
-use Illuminate\Support\Collection;
-use Laravel\Nova\Fields\ActionFields;
-use Illuminate\Queue\SerializesModels;
-use Illuminate\Queue\InteractsWithQueue;
 use Maatwebsite\LaravelNovaExcel\Actions\DownloadExcel;
 
 class ExportUsername extends DownloadExcel
@@ -26,7 +21,8 @@ class ExportUsername extends DownloadExcel
      */
     public $availableForEntireResource = true;
 
-    public function __construct() {
+    public function __construct()
+    {
         $this->withFilename('Members.csv')
             ->withWriterType(\Maatwebsite\Excel\Excel::CSV)
             ->only('uid');

--- a/app/Nova/Actions/ResetApiToken.php
+++ b/app/Nova/Actions/ResetApiToken.php
@@ -13,6 +13,14 @@ class ResetApiToken extends Action
 {
     use InteractsWithQueue, Queueable, SerializesModels;
 
+
+    /**
+     * The displayable name of the action.
+     *
+     * @var string
+     */
+    public $name = 'Reset API Token';
+
     /**
      * Perform the action on the given models.
      *

--- a/app/Nova/Actions/ResetApiToken.php
+++ b/app/Nova/Actions/ResetApiToken.php
@@ -13,7 +13,6 @@ class ResetApiToken extends Action
 {
     use InteractsWithQueue, Queueable, SerializesModels;
 
-
     /**
      * The displayable name of the action.
      *

--- a/app/Nova/Attendance.php
+++ b/app/Nova/Attendance.php
@@ -6,6 +6,7 @@ use Laravel\Nova\Panel;
 use Illuminate\Http\Request;
 use Laravel\Nova\Fields\Text;
 use App\Nova\Filters\Attendable;
+use App\Nova\Filters\UserActive;
 use Laravel\Nova\Fields\MorphTo;
 use Laravel\Nova\Fields\DateTime;
 use Laravel\Nova\Fields\BelongsTo;
@@ -133,6 +134,7 @@ class Attendance extends Resource
     {
         return [
             new Attendable,
+            new UserActive,
         ];
     }
 

--- a/app/Nova/Attendance.php
+++ b/app/Nova/Attendance.php
@@ -5,6 +5,7 @@ namespace App\Nova;
 use Laravel\Nova\Panel;
 use Illuminate\Http\Request;
 use Laravel\Nova\Fields\Text;
+use App\Nova\Filters\Attendable;
 use Laravel\Nova\Fields\MorphTo;
 use Laravel\Nova\Fields\DateTime;
 use Laravel\Nova\Fields\BelongsTo;
@@ -130,7 +131,9 @@ class Attendance extends Resource
      */
     public function filters(Request $request)
     {
-        return [];
+        return [
+            new Attendable,
+        ];
     }
 
     /**

--- a/app/Nova/Attendance.php
+++ b/app/Nova/Attendance.php
@@ -8,10 +8,10 @@ use Illuminate\Http\Request;
 use Laravel\Nova\Fields\Text;
 use App\Nova\Filters\DateFrom;
 use App\Nova\Filters\Attendable;
-use App\Nova\Filters\UserActive;
 use Laravel\Nova\Fields\MorphTo;
 use Laravel\Nova\Fields\DateTime;
 use Laravel\Nova\Fields\BelongsTo;
+use App\Nova\Filters\UserActiveAttendance;
 
 class Attendance extends Resource
 {
@@ -136,7 +136,7 @@ class Attendance extends Resource
     {
         return [
             new Attendable,
-            new UserActive,
+            new UserActiveAttendance,
             new DateFrom,
             new DateTo,
         ];

--- a/app/Nova/Attendance.php
+++ b/app/Nova/Attendance.php
@@ -11,7 +11,10 @@ use App\Nova\Filters\Attendable;
 use Laravel\Nova\Fields\MorphTo;
 use Laravel\Nova\Fields\DateTime;
 use Laravel\Nova\Fields\BelongsTo;
+use App\Nova\Lenses\RecentInactiveUsers;
 use App\Nova\Filters\UserActiveAttendance;
+use Laravel\Nova\Http\Requests\LensRequest;
+use Illuminate\Auth\Access\AuthorizationException;
 
 class Attendance extends Resource
 {
@@ -150,7 +153,9 @@ class Attendance extends Resource
      */
     public function lenses(Request $request)
     {
-        return [];
+        return [
+            new RecentInactiveUsers,
+        ];
     }
 
     /**
@@ -162,5 +167,61 @@ class Attendance extends Resource
     public function actions(Request $request)
     {
         return [];
+    }
+
+    /**
+     * Determine if the current user can view the given resource or throw an exception.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return void
+     *
+     * @throws \Illuminate\Auth\Access\AuthorizationException
+     */
+    public function authorizeToView(Request $request)
+    {
+        if ($request instanceof LensRequest) {
+            throw new AuthorizationException();
+        }
+        parent::authorizeToView($request);
+    }
+
+    /**
+     * Determine if the current user can view the given resource.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return bool
+     */
+    public function authorizedToView(Request $request)
+    {
+        // This method, and those like it, is a gross way to remove the buttons from the row in the
+        // RecentInactiveUsers lens, as they do not work on aggregated rows like that lens uses.
+        return ($request instanceof LensRequest) ? false : parent::authorizedToView($request);
+    }
+
+    /**
+     * Determine if the current user can delete the given resource or throw an exception.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return void
+     *
+     * @throws \Illuminate\Auth\Access\AuthorizationException
+     */
+    public function authorizeToDelete(Request $request)
+    {
+        if ($request instanceof LensRequest) {
+            throw new AuthorizationException();
+        }
+        parent::authorizeToDelete($request);
+    }
+
+    /**
+     * Determine if the current user can delete the given resource.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return bool
+     */
+    public function authorizedToDelete(Request $request)
+    {
+        return ($request instanceof LensRequest) ? false : parent::authorizedToDelete($request);
     }
 }

--- a/app/Nova/Attendance.php
+++ b/app/Nova/Attendance.php
@@ -3,8 +3,10 @@
 namespace App\Nova;
 
 use Laravel\Nova\Panel;
+use App\Nova\Filters\DateTo;
 use Illuminate\Http\Request;
 use Laravel\Nova\Fields\Text;
+use App\Nova\Filters\DateFrom;
 use App\Nova\Filters\Attendable;
 use App\Nova\Filters\UserActive;
 use Laravel\Nova\Fields\MorphTo;
@@ -135,6 +137,8 @@ class Attendance extends Resource
         return [
             new Attendable,
             new UserActive,
+            new DateFrom,
+            new DateTo,
         ];
     }
 

--- a/app/Nova/DuesPackage.php
+++ b/app/Nova/DuesPackage.php
@@ -8,6 +8,7 @@ use Laravel\Nova\Fields\Text;
 use Laravel\Nova\Fields\Boolean;
 use Laravel\Nova\Fields\Currency;
 use Laravel\Nova\Fields\DateTime;
+use App\Nova\Metrics\TotalCollections;
 
 class DuesPackage extends Resource
 {
@@ -131,7 +132,9 @@ class DuesPackage extends Resource
      */
     public function cards(Request $request)
     {
-        return [];
+        return [
+            (new TotalCollections())->onlyOnDetail(),
+        ];
     }
 
     /**

--- a/app/Nova/DuesPackage.php
+++ b/app/Nova/DuesPackage.php
@@ -8,6 +8,7 @@ use Laravel\Nova\Fields\Text;
 use Laravel\Nova\Fields\Boolean;
 use Laravel\Nova\Fields\Currency;
 use Laravel\Nova\Fields\DateTime;
+use App\Nova\Metrics\SwagPickupRate;
 use App\Nova\Metrics\TotalCollections;
 use App\Nova\Metrics\PaymentMethodBreakdown;
 
@@ -136,6 +137,8 @@ class DuesPackage extends Resource
         return [
             (new TotalCollections())->onlyOnDetail(),
             (new PaymentMethodBreakdown())->onlyOnDetail(),
+            (new SwagPickupRate('shirt'))->onlyOnDetail(),
+            (new SwagPickupRate('polo'))->onlyOnDetail(),
         ];
     }
 

--- a/app/Nova/DuesPackage.php
+++ b/app/Nova/DuesPackage.php
@@ -9,6 +9,7 @@ use Laravel\Nova\Fields\Boolean;
 use Laravel\Nova\Fields\Currency;
 use Laravel\Nova\Fields\DateTime;
 use App\Nova\Metrics\TotalCollections;
+use App\Nova\Metrics\PaymentMethodBreakdown;
 
 class DuesPackage extends Resource
 {
@@ -134,6 +135,7 @@ class DuesPackage extends Resource
     {
         return [
             (new TotalCollections())->onlyOnDetail(),
+            (new PaymentMethodBreakdown())->onlyOnDetail(),
         ];
     }
 

--- a/app/Nova/Event.php
+++ b/app/Nova/Event.php
@@ -11,6 +11,7 @@ use Laravel\Nova\Fields\Currency;
 use Laravel\Nova\Fields\DateTime;
 use Laravel\Nova\Fields\BelongsTo;
 use App\Nova\Metrics\RsvpSourceBreakdown;
+use App\Nova\Metrics\ActiveAttendanceBreakdown;
 
 class Event extends Resource
 {
@@ -110,6 +111,7 @@ class Event extends Resource
     {
         return [
             (new RsvpSourceBreakdown())->onlyOnDetail(),
+            (new ActiveAttendanceBreakdown(true))->onlyOnDetail(),
         ];
     }
 

--- a/app/Nova/Event.php
+++ b/app/Nova/Event.php
@@ -10,6 +10,7 @@ use Laravel\Nova\Fields\HasMany;
 use Laravel\Nova\Fields\Currency;
 use Laravel\Nova\Fields\DateTime;
 use Laravel\Nova\Fields\BelongsTo;
+use App\Nova\Metrics\RsvpSourceBreakdown;
 
 class Event extends Resource
 {
@@ -107,7 +108,9 @@ class Event extends Resource
      */
     public function cards(Request $request)
     {
-        return [];
+        return [
+            (new RsvpSourceBreakdown())->onlyOnDetail(),
+        ];
     }
 
     /**

--- a/app/Nova/Filters/Attendable.php
+++ b/app/Nova/Filters/Attendable.php
@@ -29,6 +29,7 @@ class Attendable extends Filter
         $parts = explode(',', $value);
         $attendableType = $parts[0];
         $attendableID = $parts[1];
+        if (!in_array($attendableType, ['App\Event', 'App\Team']) || !is_numeric($attendableID)) return $query;
         return $query->where('attendable_type', $attendableType)->where('attendable_id', $attendableID);
     }
 

--- a/app/Nova/Filters/Attendable.php
+++ b/app/Nova/Filters/Attendable.php
@@ -17,6 +17,23 @@ class Attendable extends Filter
     public $name = 'Attended';
 
     /**
+     * Whether to include events in the attendable options.
+     *
+     * @var boolean
+     */
+    protected $includeEvents = true;
+
+    /**
+     * Create new Attendable filter.
+     *
+     * @param  boolean  $includeEvents
+     */
+    public function __construct($includeEvents = true)
+    {
+        $this->includeEvents = $includeEvents;
+    }
+
+    /**
      * Apply the filter to the given query.
      *
      * @param  \Illuminate\Http\Request  $request
@@ -49,9 +66,9 @@ class Attendable extends Filter
         $teams = Team::where('attendable', 1)->get()->mapWithKeys(function ($item) {
             return ['Team: '.$item['name'] => 'App\Team,'.$item['id']];
         })->toArray();
-        $events = Event::all()->mapWithKeys(function ($item) {
+        $events = $this->includeEvents ? Event::all()->mapWithKeys(function ($item) {
             return ['Event: '.$item['name'] => 'App\Event,'.$item['id']];
-        })->toArray();
+        })->toArray() : [];
 
         return array_merge($teams, $events);
     }

--- a/app/Nova/Filters/Attendable.php
+++ b/app/Nova/Filters/Attendable.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace App\Nova\Filters;
+
+use App\Team;
+use App\Event;
+use Illuminate\Http\Request;
+use Laravel\Nova\Filters\Filter;
+
+class Attendable extends Filter
+{
+    /**
+     * The displayable name of the action.
+     *
+     * @var string
+     */
+    public $name = 'Attended';
+
+    /**
+     * Apply the filter to the given query.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  \Illuminate\Database\Eloquent\Builder  $query
+     * @param  mixed  $value
+     * @return \Illuminate\Database\Eloquent\Builder
+     */
+    public function apply(Request $request, $query, $value)
+    {
+        $parts = explode(',', $value);
+        $attendableType = $parts[0];
+        $attendableID = $parts[1];
+        return $query->where('attendable_type', $attendableType)->where('attendable_id', $attendableID);
+    }
+
+    /**
+     * Get the filter's available options.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return array
+     */
+    public function options(Request $request)
+    {
+        // Get all the teams and events (attendables), display them as "Team: <team name>" or "Event: <event name>"
+        // Store the value as "App\Team,##" or "App\Event,##", where ## is the ID
+        $teams = Team::where('attendable', 1)->get()->mapWithKeys(function($item) {
+            return ['Team: '.$item['name'] => 'App\Team,'.$item['id']];
+        })->toArray();
+        $events = Event::all()->mapWithKeys(function($item) {
+            return ['Event: '.$item['name'] => 'App\Event,'.$item['id']];
+        })->toArray();
+        return array_merge($teams, $events);
+    }
+}

--- a/app/Nova/Filters/Attendable.php
+++ b/app/Nova/Filters/Attendable.php
@@ -19,14 +19,14 @@ class Attendable extends Filter
     /**
      * Whether to include events in the attendable options.
      *
-     * @var boolean
+     * @var bool
      */
     protected $includeEvents = true;
 
     /**
      * Create new Attendable filter.
      *
-     * @param  boolean  $includeEvents
+     * @param  bool  $includeEvents
      */
     public function __construct($includeEvents = true)
     {

--- a/app/Nova/Filters/Attendable.php
+++ b/app/Nova/Filters/Attendable.php
@@ -29,7 +29,10 @@ class Attendable extends Filter
         $parts = explode(',', $value);
         $attendableType = $parts[0];
         $attendableID = $parts[1];
-        if (!in_array($attendableType, ['App\Event', 'App\Team']) || !is_numeric($attendableID)) return $query;
+        if (! in_array($attendableType, ['App\Event', 'App\Team']) || ! is_numeric($attendableID)) {
+            return $query;
+        }
+
         return $query->where('attendable_type', $attendableType)->where('attendable_id', $attendableID);
     }
 
@@ -43,12 +46,13 @@ class Attendable extends Filter
     {
         // Get all the teams and events (attendables), display them as "Team: <team name>" or "Event: <event name>"
         // Store the value as "App\Team,##" or "App\Event,##", where ## is the ID
-        $teams = Team::where('attendable', 1)->get()->mapWithKeys(function($item) {
+        $teams = Team::where('attendable', 1)->get()->mapWithKeys(function ($item) {
             return ['Team: '.$item['name'] => 'App\Team,'.$item['id']];
         })->toArray();
-        $events = Event::all()->mapWithKeys(function($item) {
+        $events = Event::all()->mapWithKeys(function ($item) {
             return ['Event: '.$item['name'] => 'App\Event,'.$item['id']];
         })->toArray();
+
         return array_merge($teams, $events);
     }
 }

--- a/app/Nova/Filters/DateFrom.php
+++ b/app/Nova/Filters/DateFrom.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\Nova\Filters;
+
+use R64\Filters\DateFilter;
+use Illuminate\Http\Request;
+use Laravel\Nova\Filters\Filter;
+
+class DateFrom extends DateFilter
+{
+    /**
+     * Apply the filter to the given query.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  \Illuminate\Database\Eloquent\Builder  $query
+     * @param  mixed  $value
+     * @return \Illuminate\Database\Eloquent\Builder
+     */
+    public function apply(Request $request, $query, $value)
+    {
+        return $query->whereDate('created_at', '>=', $value);
+    }
+
+    /**
+     * Get the filter's available options.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return array
+     */
+    public function options(Request $request)
+    {
+        return [
+            'dateFormat' => 'Y-m-d',
+            'placeholder' => 'Pick a date',
+            'disabled' => false,
+            'twelveHourTime' => false,
+            'enableTime' => false,
+            'enableSeconds' => false,
+        ];
+    }
+}

--- a/app/Nova/Filters/DateTo.php
+++ b/app/Nova/Filters/DateTo.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\Nova\Filters;
+
+use R64\Filters\DateFilter;
+use Illuminate\Http\Request;
+use Laravel\Nova\Filters\Filter;
+
+class DateTo extends DateFilter
+{
+    /**
+     * Apply the filter to the given query.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  \Illuminate\Database\Eloquent\Builder  $query
+     * @param  mixed  $value
+     * @return \Illuminate\Database\Eloquent\Builder
+     */
+    public function apply(Request $request, $query, $value)
+    {
+        return $query->whereDate('created_at', '<=', $value);
+    }
+
+    /**
+     * Get the filter's available options.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return array
+     */
+    public function options(Request $request)
+    {
+        return [
+            'dateFormat' => 'Y-m-d',
+            'placeholder' => 'Pick a date',
+            'disabled' => false,
+            'twelveHourTime' => false,
+            'enableTime' => false,
+            'enableSeconds' => false,
+        ];
+    }
+}

--- a/app/Nova/Filters/UserActive.php
+++ b/app/Nova/Filters/UserActive.php
@@ -4,6 +4,7 @@ namespace App\Nova\Filters;
 
 use Illuminate\Http\Request;
 use Laravel\Nova\Filters\Filter;
+use Illuminate\Support\Facades\DB;
 
 class UserActive extends Filter
 {
@@ -17,10 +18,24 @@ class UserActive extends Filter
      */
     public function apply(Request $request, $query, $value)
     {
-        if ($value === 'yes') {
-            return $query->active();
+        if ($request->resource() === 'App\Nova\User') {
+            if ($value === 'yes') {
+                return $query->active();
+            } else {
+                return $query->inactive();
+            }
+        } else if ($request->resource() === 'App\Nova\Attendance') {
+            if ($value === 'yes') {
+                return $query->whereHas('attendee', function($q) {
+                    $q->active();
+                });
+            } else {
+                return $query->whereDoesntHave('attendee', function($q) {
+                    $q->active();
+                });
+            }
         } else {
-            return $query->inactive();
+            return $query;
         }
     }
 

--- a/app/Nova/Filters/UserActive.php
+++ b/app/Nova/Filters/UserActive.php
@@ -4,7 +4,6 @@ namespace App\Nova\Filters;
 
 use Illuminate\Http\Request;
 use Laravel\Nova\Filters\Filter;
-use Illuminate\Support\Facades\DB;
 
 class UserActive extends Filter
 {
@@ -24,13 +23,13 @@ class UserActive extends Filter
             } else {
                 return $query->inactive();
             }
-        } else if ($request->resource() === 'App\Nova\Attendance') {
+        } elseif ($request->resource() === 'App\Nova\Attendance') {
             if ($value === 'yes') {
-                return $query->whereHas('attendee', function($q) {
+                return $query->whereHas('attendee', function ($q) {
                     $q->active();
                 });
             } else {
-                return $query->whereDoesntHave('attendee', function($q) {
+                return $query->whereDoesntHave('attendee', function ($q) {
                     $q->active();
                 });
             }

--- a/app/Nova/Filters/UserActiveAttendance.php
+++ b/app/Nova/Filters/UserActiveAttendance.php
@@ -5,8 +5,15 @@ namespace App\Nova\Filters;
 use Illuminate\Http\Request;
 use Laravel\Nova\Filters\Filter;
 
-class UserActive extends Filter
+class UserActiveAttendance extends Filter
 {
+    /**
+     * The displayable name of the action.
+     *
+     * @var string
+     */
+    public $name = 'User Active';
+
     /**
      * Apply the filter to the given query.
      *
@@ -18,9 +25,13 @@ class UserActive extends Filter
     public function apply(Request $request, $query, $value)
     {
         if ($value === 'yes') {
-            return $query->active();
+            return $query->whereHas('attendee', function ($q) {
+                $q->active();
+            });
         } else {
-            return $query->inactive();
+            return $query->whereDoesntHave('attendee', function ($q) {
+                $q->active();
+            });
         }
     }
 

--- a/app/Nova/Lenses/RecentInactiveUsers.php
+++ b/app/Nova/Lenses/RecentInactiveUsers.php
@@ -4,13 +4,11 @@ namespace App\Nova\Lenses;
 
 use App\Nova\Team;
 use App\Nova\Event;
-use Laravel\Nova\Fields\ID;
 use Illuminate\Http\Request;
 use Laravel\Nova\Fields\Text;
 use Laravel\Nova\Lenses\Lens;
 use App\Nova\Filters\Attendable;
 use Laravel\Nova\Fields\MorphTo;
-use Laravel\Nova\Fields\DateTime;
 use Laravel\Nova\Fields\BelongsTo;
 use Laravel\Nova\Http\Requests\LensRequest;
 

--- a/app/Nova/Lenses/RecentInactiveUsers.php
+++ b/app/Nova/Lenses/RecentInactiveUsers.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace App\Nova\Lenses;
+
+use App\Nova\Team;
+use App\Nova\Event;
+use Laravel\Nova\Fields\ID;
+use Illuminate\Http\Request;
+use Laravel\Nova\Fields\Text;
+use Laravel\Nova\Lenses\Lens;
+use App\Nova\Filters\Attendable;
+use Laravel\Nova\Fields\MorphTo;
+use Laravel\Nova\Fields\DateTime;
+use Laravel\Nova\Fields\BelongsTo;
+use Laravel\Nova\Http\Requests\LensRequest;
+
+class RecentInactiveUsers extends Lens
+{
+    /**
+     * Get the query builder / paginator for the lens.
+     *
+     * @param  \Laravel\Nova\Http\Requests\LensRequest  $request
+     * @param  \Illuminate\Database\Eloquent\Builder  $query
+     * @return mixed
+     */
+    public static function query(LensRequest $request, $query)
+    {
+        return $request->withOrdering($request->withFilters(
+            $query->whereDoesntHave('attendee', function ($q) {
+                $q->active();
+            })->where('attendable_type', 'App\Team')
+            ->whereBetween('created_at', [now()->subDays(14)->startOfDay(), now()])
+            ->select('gtid', 'attendable_id', 'attendable_type')
+            ->distinct()
+        ));
+    }
+
+    /**
+     * Get the fields available to the lens.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return array
+     */
+    public function fields(Request $request)
+    {
+        return [
+            Text::make('GTID')
+                ->sortable(),
+
+            BelongsTo::make('User', 'attendee', 'App\Nova\User')
+                ->sortable(),
+
+            MorphTo::make('Attended', 'attendable')
+                ->sortable()
+                ->types([
+                    Event::class,
+                    Team::class,
+                ]),
+        ];
+    }
+
+    /**
+     * Get the filters available for the lens.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return array
+     */
+    public function filters(Request $request)
+    {
+        return [
+            new Attendable(false),
+        ];
+    }
+
+    /**
+     * Get the URI key for the lens.
+     *
+     * @return string
+     */
+    public function uriKey()
+    {
+        return 'recent-inactive-users';
+    }
+}

--- a/app/Nova/Metrics/ActiveAttendanceBreakdown.php
+++ b/app/Nova/Metrics/ActiveAttendanceBreakdown.php
@@ -20,16 +20,16 @@ class ActiveAttendanceBreakdown extends Partition
     }
 
     /**
-     * Whether to show based on all attendance records or only those from the last two weeks
+     * Whether to show based on all attendance records or only those from the last two weeks.
      *
-     * @var boolean
+     * @var bool
      */
     protected $showAllTime = false;
 
     /**
      * Create a new ActiveAttendanceBreakdown metric.
      *
-     * @param  boolean  $showAllTime
+     * @param  bool  $showAllTime
      */
     public function __construct($showAllTime = false)
     {
@@ -65,6 +65,7 @@ class ActiveAttendanceBreakdown extends Partition
                 if (! $item->active) {
                     $key = 'Inactive';
                 }
+
                 return [$key => $item->aggregate];
             })->toArray();
 

--- a/app/Nova/Metrics/ActiveAttendanceBreakdown.php
+++ b/app/Nova/Metrics/ActiveAttendanceBreakdown.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace App\Nova\Metrics;
+
+use App\User;
+use App\Attendance;
+use Illuminate\Http\Request;
+use Laravel\Nova\Metrics\Partition;
+
+class ActiveAttendanceBreakdown extends Partition
+{
+    /**
+     * Get the displayable name of the metric.
+     *
+     * @return string
+     */
+    public function name()
+    {
+        return $this->showAllTime ? 'Active Attendees' : 'Recent Attendees';
+    }
+
+    /**
+     * Whether to show based on all attendance records or only those from the last two weeks
+     *
+     * @var boolean
+     */
+    protected $showAllTime = false;
+
+    /**
+     * Create a new ActiveAttendanceBreakdown metric.
+     *
+     * @param  boolean  $showAllTime
+     */
+    public function __construct($showAllTime = false)
+    {
+        $this->showAllTime = $showAllTime;
+    }
+
+    /**
+     * Calculate the value of the metric.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return mixed
+     */
+    public function calculate(Request $request)
+    {
+        $query = Attendance::selectRaw('count(distinct gtid) as aggregate')
+            // If a user is found, this will give "Active" in the active column, otherwise the column will be null
+            ->selectSub(User::whereRaw('attendance.gtid = users.gtid')->active()->selectRaw("'Active'"), 'active');
+
+        if ($request->resourceId) {
+            $query = $query->where('attendable_id', $request->resourceId)
+                ->where('attendable_type', get_class($request->model()));
+        }
+
+        if (! $this->showAllTime) {
+            $query = $query->whereBetween('created_at', [now()->subDays(28)->startOfDay(), now()]);
+        }
+
+        $result = $query->groupBy('active')
+            ->orderByRaw('aggregate desc, active desc')
+            ->get()
+            ->mapWithKeys(function ($item) {
+                $key = $item->active;
+                if (! $item->active) {
+                    $key = 'Inactive';
+                }
+                return [$key => $item->aggregate];
+            })->toArray();
+
+        return $this->result($result);
+    }
+
+    /**
+     * Determine for how many minutes the metric should be cached.
+     *
+     * @return  \DateTimeInterface|\DateInterval|float|int
+     */
+    public function cacheFor()
+    {
+        // return now()->addMinutes(5);
+    }
+
+    /**
+     * Get the URI key for the metric.
+     *
+     * @return string
+     */
+    public function uriKey()
+    {
+        return 'active-attendance-breakdown';
+    }
+}

--- a/app/Nova/Metrics/AttendancePerWeek.php
+++ b/app/Nova/Metrics/AttendancePerWeek.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace App\Nova\Metrics;
+
+use App\Attendance;
+use Illuminate\Http\Request;
+use Laravel\Nova\Metrics\Trend;
+
+class AttendancePerWeek extends Trend
+{
+    /**
+     * Calculate the value of the metric.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return mixed
+     */
+    public function calculate(Request $request)
+    {
+        // This is slightly hacky, but it works. Otherwise, responses with a created date of midnight (as created by
+        // some forms) were pushed back to the previous day in the metric. This acts like we're in GMT while
+        // calculating the attendance.
+        $originalTimezone = $request->timezone;
+        $request->timezone = 'Etc/GMT';
+
+        // If we're on a team page, not the main dashboard, filter to that team
+        if ($request->resourceId) {
+            $result = $this->countByWeeks($request, (new Attendance())
+                ->newQuery()
+                ->where('attendable_id', $request->resourceId)
+                ->where('attendable_type', 'App\Team')
+            )->showLatestValue();
+        } else {
+            $result = $this->countByWeeks($request, Attendance::class)->showLatestValue();
+        }
+
+        $request->timezone = $originalTimezone;
+        return $result;
+    }
+
+    /**
+     * Get the ranges available for the metric.
+     *
+     * @return array
+     */
+    public function ranges()
+    {
+        return [
+            4 => '1 Month',
+            8 => '2 Months',
+            12 => '3 Months',
+            26 => '6 Months',
+            52 => '1 Year',
+        ];
+    }
+
+    /**
+     * Determine for how many minutes the metric should be cached.
+     *
+     * @return  \DateTimeInterface|\DateInterval|float|int
+     */
+    public function cacheFor()
+    {
+        // return now()->addMinutes(5);
+    }
+
+    /**
+     * Get the URI key for the metric.
+     *
+     * @return string
+     */
+    public function uriKey()
+    {
+        return 'attendance-per-week';
+    }
+}

--- a/app/Nova/Metrics/AttendancePerWeek.php
+++ b/app/Nova/Metrics/AttendancePerWeek.php
@@ -34,6 +34,7 @@ class AttendancePerWeek extends Trend
         }
 
         $request->timezone = $originalTimezone;
+
         return $result;
     }
 

--- a/app/Nova/Metrics/AttendancePerWeek.php
+++ b/app/Nova/Metrics/AttendancePerWeek.php
@@ -47,7 +47,6 @@ class AttendancePerWeek extends Trend
     public function ranges()
     {
         return [
-            4 => '1 Month',
             8 => '2 Months',
             12 => '3 Months',
             26 => '6 Months',

--- a/app/Nova/Metrics/AttendancePerWeek.php
+++ b/app/Nova/Metrics/AttendancePerWeek.php
@@ -34,7 +34,8 @@ class AttendancePerWeek extends Trend
         }
 
         // Aggregate based on counting distinct values in the gtid column
-        $result = $this->aggregate($request, $query, Trend::BY_WEEKS, 'count', DB::raw('distinct attendance.gtid'), 'created_at');
+        $column = DB::raw('distinct attendance.gtid');
+        $result = $this->aggregate($request, $query, Trend::BY_WEEKS, 'count', $column, 'created_at');
 
         $request->timezone = $originalTimezone;
 

--- a/app/Nova/Metrics/AttendancePerWeek.php
+++ b/app/Nova/Metrics/AttendancePerWeek.php
@@ -24,11 +24,12 @@ class AttendancePerWeek extends Trend
 
         // If we're on a team page, not the main dashboard, filter to that team
         if ($request->resourceId) {
-            $result = $this->countByWeeks($request, (new Attendance())
+            $query = (new Attendance())
                 ->newQuery()
                 ->where('attendable_id', $request->resourceId)
-                ->where('attendable_type', 'App\Team')
-            )->showLatestValue();
+                ->where('attendable_type', 'App\Team');
+
+            $result = $this->countByWeeks($request, $query)->showLatestValue();
         } else {
             $result = $this->countByWeeks($request, Attendance::class)->showLatestValue();
         }

--- a/app/Nova/Metrics/MemberSince.php
+++ b/app/Nova/Metrics/MemberSince.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace App\Nova\Metrics;
+
+use App\DuesTransaction;
+use Illuminate\Http\Request;
+use Laravel\Nova\Metrics\Value;
+
+class MemberSince extends Value
+{
+    /**
+     * Calculate the value of the metric.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return mixed
+     */
+    public function calculate(Request $request)
+    {
+        // Same logic as in DashboardController
+        $date = strtotime(DuesTransaction::paid()
+            ->where('user_id', $request->resourceId)
+            ->with('package')->first()
+            ->payment->first()
+            ->created_at);
+        // The date must be passed in as the prefix, or the non-numeric characters will be stripped and it will be
+        // treated as a number. This is ugly but works. See
+        // vendor/laravel/nova/resources/js/components/Metrics/Base/ValueMetric.vue line 124.
+        return $this->result('')->prefix(date('F j, Y', $date));
+    }
+
+    /**
+     * Get the ranges available for the metric.
+     *
+     * @return array
+     */
+    public function ranges()
+    {
+        return [];
+    }
+
+    /**
+     * Determine for how many minutes the metric should be cached.
+     *
+     * @return  \DateTimeInterface|\DateInterval|float|int
+     */
+    public function cacheFor()
+    {
+        // return now()->addMinutes(5);
+    }
+
+    /**
+     * Get the URI key for the metric.
+     *
+     * @return string
+     */
+    public function uriKey()
+    {
+        return 'member-since';
+    }
+}

--- a/app/Nova/Metrics/MemberSince.php
+++ b/app/Nova/Metrics/MemberSince.php
@@ -17,15 +17,18 @@ class MemberSince extends Value
     public function calculate(Request $request)
     {
         // Same logic as in DashboardController
-        $date = strtotime(DuesTransaction::paid()
+        $transaction = DuesTransaction::paid()
             ->where('user_id', $request->resourceId)
-            ->with('package')->first()
-            ->payment->first()
-            ->created_at);
-        // The date must be passed in as the prefix, or the non-numeric characters will be stripped and it will be
-        // treated as a number. This is ugly but works. See
-        // vendor/laravel/nova/resources/js/components/Metrics/Base/ValueMetric.vue line 124.
-        return $this->result('')->prefix(date('F j, Y', $date));
+            ->with('package')->first();
+
+        if ($transaction) {
+            // The date must be passed in as the prefix, or the non-numeric characters will be stripped and it will be
+            // treated as a number. This is ugly but works. See
+            // vendor/laravel/nova/resources/js/components/Metrics/Base/ValueMetric.vue line 124.
+            return $this->result('')->prefix(date('F j, Y', strtotime($transaction->created_at)));
+        } else {
+            return $this->result('n/a');
+        }
     }
 
     /**

--- a/app/Nova/Metrics/PaymentMethodBreakdown.php
+++ b/app/Nova/Metrics/PaymentMethodBreakdown.php
@@ -38,21 +38,22 @@ class PaymentMethodBreakdown extends Partition
                 $key = $item->method;
                 switch ($item->method) {
                     case 'cash':
-                    $key = 'Cash';
-                    break;
+                        $key = 'Cash';
+                        break;
                     case 'check':
-                    $key = 'Check';
-                    break;
+                        $key = 'Check';
+                        break;
                     case 'swipe':
-                    $key = 'Swiped Card';
-                    break;
+                        $key = 'Swiped Card';
+                        break;
                     case 'square':
-                    $key = 'Square (Online)';
-                    break;
+                        $key = 'Square (Online)';
+                        break;
                     case 'squarecash':
-                    $key = 'SquareCash';
-                    break;
+                        $key = 'SquareCash';
+                        break;
                 }
+
                 return [$key => $item->aggregate];
             })->toArray()
         );

--- a/app/Nova/Metrics/PaymentMethodBreakdown.php
+++ b/app/Nova/Metrics/PaymentMethodBreakdown.php
@@ -50,7 +50,7 @@ class PaymentMethodBreakdown extends Partition
                         $key = 'Square (Online)';
                         break;
                     case 'squarecash':
-                        $key = 'SquareCash';
+                        $key = 'Square Cash';
                         break;
                 }
 

--- a/app/Nova/Metrics/PaymentMethodBreakdown.php
+++ b/app/Nova/Metrics/PaymentMethodBreakdown.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace App\Nova\Metrics;
+
+use App\Payment;
+use Illuminate\Http\Request;
+use Laravel\Nova\Metrics\Partition;
+
+class PaymentMethodBreakdown extends Partition
+{
+    /**
+     * The displayable name of the metric.
+     *
+     * @var string
+     */
+    public $name = 'Payment Methods';
+
+    /**
+     * Calculate the value of the metric.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return mixed
+     */
+    public function calculate(Request $request)
+    {
+        return $this->result(Payment::where('payable_type', 'App\DuesTransaction')
+            ->whereIn('payable_id', function ($q) use ($request) {
+                $q->select('id')
+                    ->from('dues_transactions')
+                    ->where('dues_package_id', $request->resourceId)
+                    ->whereNull('deleted_at');
+            })->select('method')
+            ->selectRaw('count(payments.id) as aggregate')
+            ->groupBy('method')
+            ->orderBy('aggregate', 'desc')
+            ->get()
+            ->mapWithKeys(function ($item) {
+                $key = $item->method;
+                switch ($item->method) {
+                    case 'cash':
+                    $key = 'Cash';
+                    break;
+                    case 'check':
+                    $key = 'Check';
+                    break;
+                    case 'swipe':
+                    $key = 'Swiped Card';
+                    break;
+                    case 'square':
+                    $key = 'Square (Online)';
+                    break;
+                    case 'squarecash':
+                    $key = 'SquareCash';
+                    break;
+                }
+                return [$key => $item->aggregate];
+            })->toArray()
+        );
+    }
+
+    /**
+     * Determine for how many minutes the metric should be cached.
+     *
+     * @return  \DateTimeInterface|\DateInterval|float|int
+     */
+    public function cacheFor()
+    {
+        // return now()->addMinutes(5);
+    }
+
+    /**
+     * Get the URI key for the metric.
+     *
+     * @return string
+     */
+    public function uriKey()
+    {
+        return 'payment-method-breakdown';
+    }
+}

--- a/app/Nova/Metrics/PrimaryTeam.php
+++ b/app/Nova/Metrics/PrimaryTeam.php
@@ -31,12 +31,12 @@ class PrimaryTeam extends Value
                 // Find start of semester date
                 if ($date->month <= 4) {
                     $date = $date->month(1)->day(1);
-                } else if ($date->month <= 7) {
+                } elseif ($date->month <= 7) {
                     $date = $date->month(5)->day(1);
                 } else {
                     $date = $date->month(8)->day(1);
                 }
-            } else if ($request->range == -2) {
+            } elseif ($request->range == -2) {
                 // Find the most recent August 1
                 $date = $date->month(8)->day(1);
                 if ($date->greaterThan(now())) {

--- a/app/Nova/Metrics/PrimaryTeam.php
+++ b/app/Nova/Metrics/PrimaryTeam.php
@@ -32,9 +32,9 @@ class PrimaryTeam extends Value
         foreach ($teams as $item) {
             if ($item['count'] == $max) {
                 $maxTeamIDs[] = $item['attendable_id'];
-            } else if ($item['count'] > $max) {
+            } elseif ($item['count'] > $max) {
                 $max = $item['count'];
-                $maxTeamIDs = [ $item['attendable_id'] ];
+                $maxTeamIDs = [$item['attendable_id']];
             }
         }
 
@@ -42,6 +42,7 @@ class PrimaryTeam extends Value
             return $this->result('No teams or attendance');
         } else {
             $names = Team::whereIn('id', $maxTeamIDs)->get()->pluck('name')->toArray();
+
             return $this->result(implode(', ', $names));
         }
     }

--- a/app/Nova/Metrics/PrimaryTeam.php
+++ b/app/Nova/Metrics/PrimaryTeam.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace App\Nova\Metrics;
+
+use App\Team;
+use App\User;
+use App\Attendance;
+use Illuminate\Http\Request;
+use Laravel\Nova\Metrics\Value;
+use Illuminate\Support\Facades\DB;
+
+class PrimaryTeam extends Value
+{
+    /**
+     * Calculate the value of the metric.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return mixed
+     */
+    public function calculate(Request $request)
+    {
+        $gtid = User::where('id', $request->resourceId)->first()->gtid;
+        \Log::info('gt'.$gtid);
+        $teams = Attendance::where('gtid', $gtid)
+            ->where('attendable_type', 'App\Team')
+            ->groupBy('attendable_id')
+            ->select('attendable_id', DB::raw('count(*) as count'))
+            ->get()->toArray();
+
+        $max = 0;
+        $maxTeamIDs = [];
+        foreach ($teams as $item) {
+            if ($item['count'] == $max) {
+                $maxTeamIDs[] = $item['attendable_id'];
+            } else if ($item['count'] > $max) {
+                $max = $item['count'];
+                $maxTeamIDs = [ $item['attendable_id'] ];
+            }
+        }
+
+        if (count($maxTeamIDs) == 0) {
+            return $this->result('No teams or attendance');
+        } else {
+            $names = Team::whereIn('id', $maxTeamIDs)->get()->pluck('name')->toArray();
+            return $this->result(implode(', ', $names));
+        }
+    }
+
+    /**
+     * Get the ranges available for the metric.
+     *
+     * @return array
+     */
+    public function ranges()
+    {
+        return [];
+    }
+
+    /**
+     * Determine for how many minutes the metric should be cached.
+     *
+     * @return  \DateTimeInterface|\DateInterval|float|int
+     */
+    public function cacheFor()
+    {
+        // return now()->addMinutes(5);
+    }
+
+    /**
+     * Get the URI key for the metric.
+     *
+     * @return string
+     */
+    public function uriKey()
+    {
+        return 'primary-team';
+    }
+}

--- a/app/Nova/Metrics/PrimaryTeam.php
+++ b/app/Nova/Metrics/PrimaryTeam.php
@@ -20,7 +20,6 @@ class PrimaryTeam extends Value
     public function calculate(Request $request)
     {
         $gtid = User::where('id', $request->resourceId)->first()->gtid;
-        \Log::info('gt'.$gtid);
         $teams = Attendance::where('gtid', $gtid)
             ->where('attendable_type', 'App\Team')
             ->groupBy('attendable_id')

--- a/app/Nova/Metrics/RsvpSourceBreakdown.php
+++ b/app/Nova/Metrics/RsvpSourceBreakdown.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace App\Nova\Metrics;
+
+use App\Rsvp;
+use Illuminate\Http\Request;
+use Laravel\Nova\Metrics\Partition;
+
+class RsvpSourceBreakdown extends Partition
+{
+    /**
+     * The displayable name of the metric.
+     *
+     * @var string
+     */
+    public $name = 'RSVP Source Breakdown';
+
+    /**
+     * Calculate the value of the metric.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return mixed
+     */
+    public function calculate(Request $request)
+    {
+        return $this->count($request, Rsvp::class, 'source')
+                    ->label(function ($value) {
+                        switch ($value) {
+                        case null:
+                            return '<unknown>';
+                        default:
+                            return $value;
+                        }
+                    });
+    }
+
+    /**
+     * Determine for how many minutes the metric should be cached.
+     *
+     * @return  \DateTimeInterface|\DateInterval|float|int
+     */
+    public function cacheFor()
+    {
+        // return now()->addMinutes(5);
+    }
+
+    /**
+     * Get the URI key for the metric.
+     *
+     * @return string
+     */
+    public function uriKey()
+    {
+        return 'rsvp-source-breakdown';
+    }
+}

--- a/app/Nova/Metrics/RsvpSourceBreakdown.php
+++ b/app/Nova/Metrics/RsvpSourceBreakdown.php
@@ -26,9 +26,9 @@ class RsvpSourceBreakdown extends Partition
         return $this->count($request, Rsvp::class, 'source')
                     ->label(function ($value) {
                         switch ($value) {
-                        case null:
+                            case null:
                             return '<unknown>';
-                        default:
+                            default:
                             return $value;
                         }
                     });

--- a/app/Nova/Metrics/SwagPickupRate.php
+++ b/app/Nova/Metrics/SwagPickupRate.php
@@ -1,0 +1,114 @@
+<?php
+
+namespace App\Nova\Metrics;
+
+use App\DuesPackage;
+use Laravel\Nova\Nova;
+use App\DuesTransaction;
+use Illuminate\Http\Request;
+use Laravel\Nova\Metrics\Value;
+
+class SwagPickupRate extends Value
+{
+    /**
+     * Get the displayable name of the metric.
+     *
+     * @return string
+     */
+    public function name()
+    {
+        return Nova::humanize($this->swagType).' Pickup Rate';
+    }
+
+    /**
+     * Which type of swag we're looking at, either 'shirt' or 'polo'
+     *
+     * @var boolean
+     */
+    protected $swagType;
+
+    /**
+     * Create a new SwagPickupRate metric. swagType can be either 'shirt' or 'polo'.
+     *
+     * @param  boolean  $swagType
+     */
+    public function __construct($swagType)
+    {
+        if (! in_array($swagType, ['shirt', 'polo'])) {
+            \Log::error('Invalid swag type given to SwagPickupRate metric: "'.$swagType.'"');
+            abort(400, 'Invalid swag type');
+            return;
+        }
+
+        $this->swagType = $swagType;
+    }
+
+    /**
+     * Calculate the value of the metric.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return mixed
+     */
+    public function calculate(Request $request)
+    {
+        $package = DuesPackage::where('id', $request->resourceId)->first();
+        $eligible = $this->swagType == 'shirt' ? $package->eligible_for_shirt : $package->eligible_for_polo;
+
+        if (! $eligible) {
+            return $this->result('n/a');
+        }
+
+        $result = DuesTransaction::where('dues_package_id', $request->resourceId)
+            ->selectRaw('`swag_'.$this->swagType.'_provided` is not null as provided')
+            ->selectRaw('count(id) as aggregate')
+            ->groupBy('provided')
+            ->get()
+            ->mapWithKeys(function ($item) {
+                return [$item->provided ? 'true' : 'false' => $item->aggregate];
+            })->toArray();
+
+        $hasAnyPickedUp = isset($result['true']);
+        $hasAnyNotPickedUp = isset($result['false']);
+
+        if ($hasAnyPickedUp && $hasAnyNotPickedUp) {
+            $value = sprintf('%.1f', ($result['true'] / ($result['true'] + $result['false']) * 100));
+            return $this->result($value.'%');
+        } else if ($hasAnyPickedUp) {
+            return $this->result('100%');
+        } else if ($hasAnyNotPickedUp) {
+            return $this->result('0%');
+        } else {
+            return $this->result('No transactions');
+        }
+    }
+
+    /**
+     * Get the ranges available for the metric.
+     *
+     * @return array
+     */
+    public function ranges()
+    {
+        return [];
+    }
+
+    /**
+     * Determine for how many minutes the metric should be cached.
+     *
+     * @return  \DateTimeInterface|\DateInterval|float|int
+     */
+    public function cacheFor()
+    {
+        // return now()->addMinutes(5);
+    }
+
+    /**
+     * Get the URI key for the metric.
+     *
+     * @return string
+     */
+    public function uriKey()
+    {
+        return 'swag-pickup-rate-'.$this->swagType;
+    }
+}

--- a/app/Nova/Metrics/SwagPickupRate.php
+++ b/app/Nova/Metrics/SwagPickupRate.php
@@ -21,22 +21,23 @@ class SwagPickupRate extends Value
     }
 
     /**
-     * Which type of swag we're looking at, either 'shirt' or 'polo'
+     * Which type of swag we're looking at, either 'shirt' or 'polo'.
      *
-     * @var boolean
+     * @var bool
      */
     protected $swagType;
 
     /**
      * Create a new SwagPickupRate metric. swagType can be either 'shirt' or 'polo'.
      *
-     * @param  boolean  $swagType
+     * @param  bool  $swagType
      */
     public function __construct($swagType)
     {
         if (! in_array($swagType, ['shirt', 'polo'])) {
             \Log::error('Invalid swag type given to SwagPickupRate metric: "'.$swagType.'"');
             abort(400, 'Invalid swag type');
+
             return;
         }
 
@@ -72,10 +73,11 @@ class SwagPickupRate extends Value
 
         if ($hasAnyPickedUp && $hasAnyNotPickedUp) {
             $value = sprintf('%.1f', ($result['true'] / ($result['true'] + $result['false']) * 100));
+
             return $this->result($value.'%');
-        } else if ($hasAnyPickedUp) {
+        } elseif ($hasAnyPickedUp) {
             return $this->result('100%');
-        } else if ($hasAnyNotPickedUp) {
+        } elseif ($hasAnyNotPickedUp) {
             return $this->result('0%');
         } else {
             return $this->result('No transactions');

--- a/app/Nova/Metrics/TotalAttendance.php
+++ b/app/Nova/Metrics/TotalAttendance.php
@@ -26,10 +26,7 @@ class TotalAttendance extends Value
         $gtid = User::where('id', $request->resourceId)->first()->gtid;
         // If a subrange is selected, let the library do the work, otherwise just count everything
         if ($request->range > 0) {
-            $result = $this->count($request, (new Attendance())
-                ->newQuery()
-                ->where('gtid', $gtid)
-            );
+            $result = $this->count($request, (new Attendance())->newQuery()->where('gtid', $gtid));
         } else {
             $result = $this->result(Attendance::where('gtid', $gtid)->count());
         }

--- a/app/Nova/Metrics/TotalAttendance.php
+++ b/app/Nova/Metrics/TotalAttendance.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace App\Nova\Metrics;
+
+use App\User;
+use App\Attendance;
+use Illuminate\Http\Request;
+use Laravel\Nova\Metrics\Value;
+
+class TotalAttendance extends Value
+{
+    /**
+     * Calculate the value of the metric.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return mixed
+     */
+    public function calculate(Request $request)
+    {
+        // This is slightly hacky, but it works. Otherwise, responses with a created date of midnight (as created by
+        // some forms) were pushed back to the previous day in the metric. This acts like we're in GMT while
+        // calculating the attendance.
+        $originalTimezone = $request->timezone;
+        $request->timezone = 'Etc/GMT';
+
+        $gtid = User::where('id', $request->resourceId)->first()->gtid;
+        // If we're on a team page, not the main dashboard, filter to that team
+        if ($request->range > 0) {
+            $result = $this->count($request, (new Attendance())
+                ->newQuery()
+                ->where('gtid', $gtid)
+            );
+        } else {
+            $result = $this->result(Attendance::where('gtid', $gtid)->count());
+        }
+
+        $request->timezone = $originalTimezone;
+        return $result;
+    }
+
+    /**
+     * Get the ranges available for the metric.
+     *
+     * @return array
+     */
+    public function ranges()
+    {
+        return [
+            -1 => 'All',
+            7 => '7 Days',
+            14 => '14 Days',
+            30 => '30 Days',
+            60 => '60 Days',
+            365 => '365 Days',
+        ];
+    }
+
+    /**
+     * Determine for how many minutes the metric should be cached.
+     *
+     * @return  \DateTimeInterface|\DateInterval|float|int
+     */
+    public function cacheFor()
+    {
+        // return now()->addMinutes(5);
+    }
+
+    /**
+     * Get the URI key for the metric.
+     *
+     * @return string
+     */
+    public function uriKey()
+    {
+        return 'total-attendance';
+    }
+}

--- a/app/Nova/Metrics/TotalAttendance.php
+++ b/app/Nova/Metrics/TotalAttendance.php
@@ -24,7 +24,7 @@ class TotalAttendance extends Value
         $request->timezone = 'Etc/GMT';
 
         $gtid = User::where('id', $request->resourceId)->first()->gtid;
-        // If we're on a team page, not the main dashboard, filter to that team
+        // If a subrange is selected, let the library do the work, otherwise just count everything
         if ($request->range > 0) {
             $result = $this->count($request, (new Attendance())
                 ->newQuery()

--- a/app/Nova/Metrics/TotalAttendance.php
+++ b/app/Nova/Metrics/TotalAttendance.php
@@ -35,6 +35,7 @@ class TotalAttendance extends Value
         }
 
         $request->timezone = $originalTimezone;
+
         return $result;
     }
 

--- a/app/Nova/Metrics/TotalCollections.php
+++ b/app/Nova/Metrics/TotalCollections.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace App\Nova\Metrics;
+
+use App\Payment;
+use Illuminate\Http\Request;
+use Laravel\Nova\Metrics\Value;
+
+class TotalCollections extends Value
+{
+    /**
+     * Calculate the value of the metric.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return mixed
+     */
+    public function calculate(Request $request)
+    {
+        $query = Payment::where('payable_type', 'App\DuesTransaction')
+            ->whereIn('payable_id', function($q) use ($request) {
+                $q->select('id')
+                    ->from('dues_transactions')
+                    ->where('dues_package_id', $request->resourceId)
+                    ->whereNull('deleted_at');
+            });
+        if ($request->range > 0) {
+            $query = $query->whereBetween('created_at', [now()->subDays($request->range)->startOfDay(), now()]);
+        }
+        return $this->result($query->sum('amount'));
+    }
+
+    /**
+     * Get the ranges available for the metric.
+     *
+     * @return array
+     */
+    public function ranges()
+    {
+        return [
+            -1 => 'All',
+            7 => '7 Days',
+            14 => '14 Days',
+            30 => '30 Days',
+            60 => '60 Days',
+        ];
+    }
+
+    /**
+     * Determine for how many minutes the metric should be cached.
+     *
+     * @return  \DateTimeInterface|\DateInterval|float|int
+     */
+    public function cacheFor()
+    {
+        // return now()->addMinutes(5);
+    }
+
+    /**
+     * Get the URI key for the metric.
+     *
+     * @return string
+     */
+    public function uriKey()
+    {
+        return 'total-collections';
+    }
+}

--- a/app/Nova/Metrics/TotalCollections.php
+++ b/app/Nova/Metrics/TotalCollections.php
@@ -17,7 +17,7 @@ class TotalCollections extends Value
     public function calculate(Request $request)
     {
         $query = Payment::where('payable_type', 'App\DuesTransaction')
-            ->whereIn('payable_id', function($q) use ($request) {
+            ->whereIn('payable_id', function ($q) use ($request) {
                 $q->select('id')
                     ->from('dues_transactions')
                     ->where('dues_package_id', $request->resourceId)
@@ -26,6 +26,7 @@ class TotalCollections extends Value
         if ($request->range > 0) {
             $query = $query->whereBetween('created_at', [now()->subDays($request->range)->startOfDay(), now()]);
         }
+
         return $this->result($query->sum('amount'));
     }
 

--- a/app/Nova/Metrics/TotalCollections.php
+++ b/app/Nova/Metrics/TotalCollections.php
@@ -27,7 +27,7 @@ class TotalCollections extends Value
             $query = $query->whereBetween('created_at', [now()->subDays($request->range)->startOfDay(), now()]);
         }
 
-        return $this->result($query->sum('amount'));
+        return $this->result($query->sum('amount'))->dollars();
     }
 
     /**

--- a/app/Nova/Team.php
+++ b/app/Nova/Team.php
@@ -12,6 +12,7 @@ use Laravel\Nova\Fields\DateTime;
 use Laravel\Nova\Fields\Textarea;
 use App\Nova\Metrics\ActiveMembers;
 use App\Nova\Metrics\TotalTeamMembers;
+use App\Nova\Metrics\AttendancePerWeek;
 
 class Team extends Resource
 {
@@ -129,6 +130,7 @@ class Team extends Resource
         return [
             (new TotalTeamMembers())->onlyOnDetail(),
             (new ActiveMembers())->onlyOnDetail(),
+            (new AttendancePerWeek())->onlyOnDetail(),
         ];
     }
 

--- a/app/Nova/Team.php
+++ b/app/Nova/Team.php
@@ -13,6 +13,7 @@ use Laravel\Nova\Fields\Textarea;
 use App\Nova\Metrics\ActiveMembers;
 use App\Nova\Metrics\TotalTeamMembers;
 use App\Nova\Metrics\AttendancePerWeek;
+use App\Nova\Metrics\ActiveAttendanceBreakdown;
 
 class Team extends Resource
 {
@@ -131,6 +132,7 @@ class Team extends Resource
             (new TotalTeamMembers())->onlyOnDetail(),
             (new ActiveMembers())->onlyOnDetail(),
             (new AttendancePerWeek())->onlyOnDetail(),
+            (new ActiveAttendanceBreakdown())->onlyOnDetail(),
         ];
     }
 

--- a/app/Nova/User.php
+++ b/app/Nova/User.php
@@ -12,6 +12,7 @@ use Laravel\Nova\Fields\HasMany;
 use App\Nova\Metrics\MemberSince;
 use Laravel\Nova\Fields\DateTime;
 use Laravel\Nova\Fields\MorphToMany;
+use App\Nova\Metrics\TotalAttendance;
 use Laravel\Nova\Fields\BelongsToMany;
 
 class User extends Resource
@@ -175,6 +176,7 @@ class User extends Resource
     {
         return [
             (new MemberSince())->onlyOnDetail(),
+            (new TotalAttendance())->onlyOnDetail(),
         ];
     }
 

--- a/app/Nova/User.php
+++ b/app/Nova/User.php
@@ -12,6 +12,7 @@ use Laravel\Nova\Fields\HasMany;
 use Laravel\Nova\Fields\DateTime;
 use Laravel\Nova\Fields\MorphToMany;
 use Laravel\Nova\Fields\BelongsToMany;
+use Maatwebsite\LaravelNovaExcel\Actions\DownloadExcel;
 
 class User extends Resource
 {

--- a/app/Nova/User.php
+++ b/app/Nova/User.php
@@ -9,6 +9,7 @@ use Laravel\Nova\Fields\Number;
 use Laravel\Nova\Fields\Select;
 use Laravel\Nova\Fields\Boolean;
 use Laravel\Nova\Fields\HasMany;
+use App\Nova\Metrics\MemberSince;
 use Laravel\Nova\Fields\DateTime;
 use Laravel\Nova\Fields\MorphToMany;
 use Laravel\Nova\Fields\BelongsToMany;
@@ -172,7 +173,9 @@ class User extends Resource
      */
     public function cards(Request $request)
     {
-        return [];
+        return [
+            (new MemberSince())->onlyOnDetail(),
+        ];
     }
 
     /**

--- a/app/Nova/User.php
+++ b/app/Nova/User.php
@@ -10,6 +10,7 @@ use Laravel\Nova\Fields\Select;
 use Laravel\Nova\Fields\Boolean;
 use Laravel\Nova\Fields\HasMany;
 use App\Nova\Metrics\MemberSince;
+use App\Nova\Metrics\PrimaryTeam;
 use Laravel\Nova\Fields\DateTime;
 use Laravel\Nova\Fields\MorphToMany;
 use App\Nova\Metrics\TotalAttendance;
@@ -177,6 +178,7 @@ class User extends Resource
         return [
             (new MemberSince())->onlyOnDetail(),
             (new TotalAttendance())->onlyOnDetail(),
+            (new PrimaryTeam())->onlyOnDetail(),
         ];
     }
 

--- a/app/Nova/User.php
+++ b/app/Nova/User.php
@@ -12,7 +12,6 @@ use Laravel\Nova\Fields\HasMany;
 use Laravel\Nova\Fields\DateTime;
 use Laravel\Nova\Fields\MorphToMany;
 use Laravel\Nova\Fields\BelongsToMany;
-use Maatwebsite\LaravelNovaExcel\Actions\DownloadExcel;
 
 class User extends Resource
 {
@@ -211,6 +210,8 @@ class User extends Resource
     {
         return [
             new Actions\ResetApiToken,
+            new Actions\ExportGtid,
+            new Actions\ExportUsername,
         ];
     }
 }

--- a/app/Providers/NovaServiceProvider.php
+++ b/app/Providers/NovaServiceProvider.php
@@ -8,6 +8,7 @@ use App\Nova\Metrics\PaymentsPerDay;
 use Illuminate\Support\Facades\Gate;
 use Laravel\Nova\Events\ServingNova;
 use App\Nova\Metrics\AttendancePerWeek;
+use App\Nova\Metrics\ActiveAttendanceBreakdown;
 use Laravel\Nova\NovaApplicationServiceProvider;
 
 class NovaServiceProvider extends NovaApplicationServiceProvider
@@ -63,6 +64,7 @@ class NovaServiceProvider extends NovaApplicationServiceProvider
             new PaymentsPerDay,
             new ActiveMembers,
             new AttendancePerWeek,
+            new ActiveAttendanceBreakdown,
         ];
     }
 

--- a/app/Providers/NovaServiceProvider.php
+++ b/app/Providers/NovaServiceProvider.php
@@ -7,6 +7,7 @@ use App\Nova\Metrics\ActiveMembers;
 use App\Nova\Metrics\PaymentsPerDay;
 use Illuminate\Support\Facades\Gate;
 use Laravel\Nova\Events\ServingNova;
+use App\Nova\Metrics\AttendancePerWeek;
 use Laravel\Nova\NovaApplicationServiceProvider;
 
 class NovaServiceProvider extends NovaApplicationServiceProvider
@@ -61,6 +62,7 @@ class NovaServiceProvider extends NovaApplicationServiceProvider
         return [
             new PaymentsPerDay,
             new ActiveMembers,
+            new AttendancePerWeek,
         ];
     }
 

--- a/composer.json
+++ b/composer.json
@@ -11,6 +11,7 @@
     "type": "project",
     "require": {
         "php": ">=7.1.3",
+        "64robots/nova-date-filter": "^0.1.0",
         "apereo/phpCAS": "dev-master",
         "bugsnag/bugsnag-laravel": "^2.0",
         "doctrine/dbal": "^2.5",

--- a/composer.json
+++ b/composer.json
@@ -20,6 +20,7 @@
         "laravel/horizon": "^1.4",
         "laravel/nova": "~1.0",
         "laravel/tinker": "~1.0",
+        "maatwebsite/laravel-nova-excel": "^1.0",
         "predis/predis": "~1.0",
         "spatie/laravel-permission": "^2.6",
         "spatie/laravel-sluggable": "^2.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,51 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "94be1a7538fa9fbbc21c2541f71cd54b",
+    "content-hash": "45788842acf6bc9144fcfc6329bf60db",
     "packages": [
+        {
+            "name": "64robots/nova-date-filter",
+            "version": "0.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/64robots/nova-date-filter.git",
+                "reference": "a0a33d175a650f14ff948d98254997c909a5f4a7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/64robots/nova-date-filter/zipball/a0a33d175a650f14ff948d98254997c909a5f4a7",
+                "reference": "a0a33d175a650f14ff948d98254997c909a5f4a7",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1.0"
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "providers": [
+                        "R64\\Filters\\FieldServiceProvider"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "R64\\Filters\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "A Laravel Nova date filter.",
+            "keywords": [
+                "date",
+                "filter",
+                "laravel",
+                "nova"
+            ],
+            "time": "2018-10-08T06:31:06+00:00"
+        },
         {
             "name": "apereo/phpcas",
             "version": "dev-master",

--- a/composer.lock
+++ b/composer.lock
@@ -1,10 +1,10 @@
 {
     "_readme": [
         "This file locks the dependencies of your project to a known state",
-        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "54a9ef42a101039457544ad365112309",
+    "content-hash": "94be1a7538fa9fbbc21c2541f71cd54b",
     "packages": [
         {
             "name": "apereo/phpcas",
@@ -1631,6 +1631,221 @@
             "time": "2018-09-14T15:30:29+00:00"
         },
         {
+            "name": "maatwebsite/excel",
+            "version": "3.1.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Maatwebsite/Laravel-Excel.git",
+                "reference": "a80179c3f33d06fc0d7f22891d6aae4bb083f8c3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Maatwebsite/Laravel-Excel/zipball/a80179c3f33d06fc0d7f22891d6aae4bb083f8c3",
+                "reference": "a80179c3f33d06fc0d7f22891d6aae4bb083f8c3",
+                "shasum": ""
+            },
+            "require": {
+                "illuminate/support": "5.5.* || 5.6.* || 5.7.*",
+                "php": "^7.0",
+                "phpoffice/phpspreadsheet": "^1.4"
+            },
+            "require-dev": {
+                "mockery/mockery": "^1.1",
+                "orchestra/database": "^3.6",
+                "orchestra/testbench": "^3.6",
+                "phpunit/phpunit": "^7.0",
+                "predis/predis": "^1.1"
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "providers": [
+                        "Maatwebsite\\Excel\\ExcelServiceProvider"
+                    ],
+                    "aliases": {
+                        "Excel": "Maatwebsite\\Excel\\Facades\\Excel"
+                    }
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Maatwebsite\\Excel\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Patrick Brouwers",
+                    "email": "patrick@maatwebsite.nl"
+                }
+            ],
+            "description": "Supercharged Excel exports and imports in Laravel",
+            "keywords": [
+                "PHPExcel",
+                "batch",
+                "csv",
+                "excel",
+                "export",
+                "import",
+                "laravel",
+                "php",
+                "phpspreadsheet"
+            ],
+            "time": "2018-10-11T09:21:58+00:00"
+        },
+        {
+            "name": "maatwebsite/laravel-nova-excel",
+            "version": "1.0.6",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Maatwebsite/Laravel-Nova-Excel.git",
+                "reference": "085ef66ea6963e8567a6a578a8533f5da9b6c620"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Maatwebsite/Laravel-Nova-Excel/zipball/085ef66ea6963e8567a6a578a8533f5da9b6c620",
+                "reference": "085ef66ea6963e8567a6a578a8533f5da9b6c620",
+                "shasum": ""
+            },
+            "require": {
+                "illuminate/support": "^5.6",
+                "laravel/nova": "*",
+                "maatwebsite/excel": "^3.0.10",
+                "php": ">=7.1.0"
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "providers": [
+                        "Maatwebsite\\LaravelNovaExcel\\LaravelNovaExcelServiceProvider"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Maatwebsite\\LaravelNovaExcel\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Patrick Brouwers",
+                    "email": "patrick@maatwebsite.nl"
+                }
+            ],
+            "description": "Supercharged Excel exports for Laravel Nova Resources",
+            "keywords": [
+                "PHPExcel",
+                "actions",
+                "laravel",
+                "laravel-nova",
+                "nova",
+                "phpspreadsheet"
+            ],
+            "time": "2018-09-17T18:39:08+00:00"
+        },
+        {
+            "name": "markbaker/complex",
+            "version": "1.4.6",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/MarkBaker/PHPComplex.git",
+                "reference": "a78d82ae4e682c3809fc3023d1b0ce654f6ab12b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/MarkBaker/PHPComplex/zipball/a78d82ae4e682c3809fc3023d1b0ce654f6ab12b",
+                "reference": "a78d82ae4e682c3809fc3023d1b0ce654f6ab12b",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.6.0|^7.0.0"
+            },
+            "require-dev": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.4.3",
+                "phpcompatibility/php-compatibility": "^8.0",
+                "phpdocumentor/phpdocumentor": "2.*",
+                "phploc/phploc": "2.*",
+                "phpmd/phpmd": "2.*",
+                "phpunit/phpunit": "^4.8.35|^5.4.0",
+                "sebastian/phpcpd": "2.*",
+                "squizlabs/php_codesniffer": "^3.3.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Complex\\": "classes/src/"
+                },
+                "files": [
+                    "classes/src/functions/abs.php",
+                    "classes/src/functions/acos.php",
+                    "classes/src/functions/acosh.php",
+                    "classes/src/functions/acot.php",
+                    "classes/src/functions/acoth.php",
+                    "classes/src/functions/acsc.php",
+                    "classes/src/functions/acsch.php",
+                    "classes/src/functions/argument.php",
+                    "classes/src/functions/asec.php",
+                    "classes/src/functions/asech.php",
+                    "classes/src/functions/asin.php",
+                    "classes/src/functions/asinh.php",
+                    "classes/src/functions/atan.php",
+                    "classes/src/functions/atanh.php",
+                    "classes/src/functions/conjugate.php",
+                    "classes/src/functions/cos.php",
+                    "classes/src/functions/cosh.php",
+                    "classes/src/functions/cot.php",
+                    "classes/src/functions/coth.php",
+                    "classes/src/functions/csc.php",
+                    "classes/src/functions/csch.php",
+                    "classes/src/functions/exp.php",
+                    "classes/src/functions/inverse.php",
+                    "classes/src/functions/ln.php",
+                    "classes/src/functions/log2.php",
+                    "classes/src/functions/log10.php",
+                    "classes/src/functions/negative.php",
+                    "classes/src/functions/pow.php",
+                    "classes/src/functions/rho.php",
+                    "classes/src/functions/sec.php",
+                    "classes/src/functions/sech.php",
+                    "classes/src/functions/sin.php",
+                    "classes/src/functions/sinh.php",
+                    "classes/src/functions/sqrt.php",
+                    "classes/src/functions/tan.php",
+                    "classes/src/functions/tanh.php",
+                    "classes/src/functions/theta.php",
+                    "classes/src/operations/add.php",
+                    "classes/src/operations/subtract.php",
+                    "classes/src/operations/multiply.php",
+                    "classes/src/operations/divideby.php",
+                    "classes/src/operations/divideinto.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Mark Baker",
+                    "email": "mark@lange.demon.co.uk"
+                }
+            ],
+            "description": "PHP Class for working with complex numbers",
+            "homepage": "https://github.com/MarkBaker/PHPComplex",
+            "keywords": [
+                "complex",
+                "mathematics"
+            ],
+            "time": "2018-07-31T08:38:40+00:00"
+        },
+        {
             "name": "monolog/monolog",
             "version": "1.23.0",
             "source": {
@@ -1905,6 +2120,93 @@
                 "random"
             ],
             "time": "2018-07-02T15:55:56+00:00"
+        },
+        {
+            "name": "phpoffice/phpspreadsheet",
+            "version": "1.4.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/PHPOffice/PhpSpreadsheet.git",
+                "reference": "57404f43742a8164b5eac3ab03b962d8740885c1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/PHPOffice/PhpSpreadsheet/zipball/57404f43742a8164b5eac3ab03b962d8740885c1",
+                "reference": "57404f43742a8164b5eac3ab03b962d8740885c1",
+                "shasum": ""
+            },
+            "require": {
+                "ext-ctype": "*",
+                "ext-dom": "*",
+                "ext-gd": "*",
+                "ext-iconv": "*",
+                "ext-libxml": "*",
+                "ext-mbstring": "*",
+                "ext-simplexml": "*",
+                "ext-xml": "*",
+                "ext-xmlreader": "*",
+                "ext-xmlwriter": "*",
+                "ext-zip": "*",
+                "ext-zlib": "*",
+                "markbaker/complex": "^1.4.1",
+                "php": "^5.6|^7.0",
+                "psr/simple-cache": "^1.0"
+            },
+            "require-dev": {
+                "dompdf/dompdf": "^0.8.0",
+                "friendsofphp/php-cs-fixer": "@stable",
+                "jpgraph/jpgraph": "^4.0",
+                "mpdf/mpdf": "^7.0.0",
+                "phpunit/phpunit": "^5.7",
+                "squizlabs/php_codesniffer": "^3.3",
+                "tecnickcom/tcpdf": "^6.2"
+            },
+            "suggest": {
+                "dompdf/dompdf": "Option for rendering PDF with PDF Writer",
+                "jpgraph/jpgraph": "Option for rendering charts, or including charts with PDF or HTML Writers",
+                "mpdf/mpdf": "Option for rendering PDF with PDF Writer",
+                "tecnickcom/tcpdf": "Option for rendering PDF with PDF Writer"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "PhpOffice\\PhpSpreadsheet\\": "src/PhpSpreadsheet"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "LGPL-2.1-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Maarten Balliauw",
+                    "homepage": "http://blog.maartenballiauw.be"
+                },
+                {
+                    "name": "Erik Tilt"
+                },
+                {
+                    "name": "Franck Lefevre",
+                    "homepage": "http://rootslabs.net"
+                },
+                {
+                    "name": "Mark Baker",
+                    "homepage": "http://markbakeruk.net"
+                }
+            ],
+            "description": "PHPSpreadsheet - Read, Create and Write Spreadsheet documents in PHP - Spreadsheet engine",
+            "homepage": "https://github.com/PHPOffice/PhpSpreadsheet",
+            "keywords": [
+                "OpenXML",
+                "excel",
+                "gnumeric",
+                "ods",
+                "php",
+                "spreadsheet",
+                "xls",
+                "xlsx"
+            ],
+            "time": "2018-09-30T03:57:24+00:00"
         },
         {
             "name": "predis/predis",

--- a/config/app.php
+++ b/config/app.php
@@ -165,6 +165,8 @@ return [
         Subfission\Cas\CasServiceProvider::class,
         Bugsnag\BugsnagLaravel\BugsnagServiceProvider::class,
         UxWeb\SweetAlert\SweetAlertServiceProvider::class,
+        Maatwebsite\Excel\ExcelServiceProvider::class,
+        Maatwebsite\LaravelNovaExcel\LaravelNovaExcelServiceProvider::class,
 
         /*
          * Application Service Providers...

--- a/resources/assets/js/components/AcceptPayment.vue
+++ b/resources/assets/js/components/AcceptPayment.vue
@@ -85,14 +85,14 @@
               <p class="font-weight-bold">TREASURER USE ONLY!</p> Square will usually automatically enter a payment. Only use this if you've confirmed that a payment went through in the Square dashboard but didn't update here.
               <ul>
                   <li>Square transactions incur a $3 processing fee. Add $3 to payment amount.</li>
-                  <li>This is <em>not</em> the same as SquareCash.</li>
+                  <li>This is <em>not</em> the same as Square Cash.</li>
               </ul>
             </template>
             <template v-else-if="payment.method == 'squarecash'">
-              <p class="font-weight-bold">TREASURER USE ONLY!</p> Check with the treasurer before marking SquareCash payments as complete.
+              <p class="font-weight-bold">TREASURER USE ONLY!</p> Check with the treasurer before marking Square Cash payments as complete.
               <ol>
                 <li>View the email saying that the money has been deposited into our account. This is the second email of a given transaction.</li>
-                <li>It is not required to provide a paper receipt for SquareCash transactions.</li>
+                <li>It is not required to provide a paper receipt for Square Cash transactions.</li>
               </ol>
             </template>
           </div>
@@ -186,7 +186,7 @@ export default {
         { value: 'check', text: 'Check' },
         { value: 'swipe', text: 'Swiped Card' },
         { value: 'square', text: 'Square (Online)' },
-        { value: 'squarecash', text: 'SquareCash' },
+        { value: 'squarecash', text: 'Square Cash' },
       ].filter(item => {
         return (paymentMethods.indexOf(item.value) != -1);
       });


### PR DESCRIPTION
Add lots of reporting, mostly through the form of Nova metrics, Nova filters, and exports. This adds [laravel-nova-excel](https://github.com/maatwebsite/laravel-nova-excel) for CSV exports from tables (username and GTID exporting from the user table per #194), and [nova-date-filter](https://github.com/64robots/nova-date-filter) for filtering by start and end dates in the attendance table. (Note that the former will require the PHP GD plugin to be installed.) The exports from the user table are either usernames only or GTIDs only so there's less of a concern about making that data easier to export in bulk.

User cards (primary team is the team(s) with the most attendance records):
<img width="1004" alt="image" src="https://user-images.githubusercontent.com/291371/46902328-9890b400-ce91-11e8-83e8-1b598c720a76.png">

Event RSVP source card:
<img width="354" alt="image" src="https://user-images.githubusercontent.com/291371/46902337-cd9d0680-ce91-11e8-988e-c980dce1020d.png">

Team attendance per week card (also on the dashboard, shows actual values if you hover):
<img width="800" alt="image" src="https://user-images.githubusercontent.com/291371/46902353-1228a200-ce92-11e8-8f53-cf220ecc6d32.png">

Attendance filters:
<img width="281" alt="image" src="https://user-images.githubusercontent.com/291371/46902368-4f8d2f80-ce92-11e8-9b6d-93d208ac539d.png">

Total collections metric:
<img width="333" alt="image" src="https://user-images.githubusercontent.com/291371/46906676-46718200-ced5-11e8-9c03-cbedc532f2ad.png">

Fixes #510. Progress towards #194 except the unique attendees per team report, which will come with #384. For now, the team pages have a metric with a small graph of the weekly attendance.