### PR TITLE
Add "fast-read" kiosk checkbox

### DIFF
--- a/resources/assets/js/components/attendance/AttendanceKiosk.vue
+++ b/resources/assets/js/components/attendance/AttendanceKiosk.vue
@@ -182,12 +182,10 @@ export default {
           showCancelButton: true,
           showConfirmButton: false,
           type: 'warning',
-        }).then(result => {
-          if (!result.value) {
+          onClose: () => {
             self.clearFields();
-            swal.close();
           }
-        });
+        })
       } else {
         swal.close();
         console.log('unknown cardData: ' + cardData);
@@ -198,10 +196,10 @@ export default {
           showConfirmButton: true,
           type: 'error',
           timer: 3000,
-        }).then(result => {
-          self.clearFields();
-          swal.close();
-        });
+          onClose: () => {
+            self.clearFields();
+          }
+        })
       }
     },
     submit() {
@@ -229,6 +227,7 @@ export default {
           console.log(error);
           this.hasError = true;
           this.feedback = '';
+          this.clearFields();
           if (error.response.status == 403) {
             swal({
               title: 'Whoops!',

--- a/resources/assets/js/components/attendance/AttendanceKiosk.vue
+++ b/resources/assets/js/components/attendance/AttendanceKiosk.vue
@@ -131,11 +131,11 @@ export default {
       document.activeElement.blur();
       // When a team button is clicked, show a prompt to swipe BuzzCard
       this.attendance.attendable_id = event.target.id;
-      swal(this.getTeamSwalConfig(event.target.id, event.target.innerText));
+      swal(this.getTeamSwalConfig(event.target.innerText));
     },
-    getTeamSwalConfig: function(teamId, teamName) {
+    getTeamSwalConfig: function(teamName) {
       if (teamName === undefined) {
-        const targetTeams = this.teams.filter(team => team.id === teamId);
+        const targetTeams = this.teams.filter(team => team.id === this.attendance.attendable_id);
         if (targetTeams.length === 1) {
           teamName = targetTeams[0].name;
         }
@@ -229,7 +229,7 @@ export default {
             type: 'success',
           }).then(() => {
             if (this.stickToTeam) {
-              swal(this.getTeamSwalConfig(this.attendance.attendable_id));
+              swal(this.getTeamSwalConfig());
             }
           });
           if (!this.stickToTeam) {

--- a/resources/assets/js/components/attendance/AttendanceKiosk.vue
+++ b/resources/assets/js/components/attendance/AttendanceKiosk.vue
@@ -136,7 +136,6 @@ export default {
         title: 'Swipe your BuzzCard now',
         html: event.target.innerText, // displays team name
         showCancelButton: true,
-        closeOnCancel: false,
         allowOutsideClick: true,
         showConfirmButton: false,
         imageUrl: '/img/swipe-horiz-up.gif',

--- a/resources/assets/js/components/attendance/AttendanceKiosk.vue
+++ b/resources/assets/js/components/attendance/AttendanceKiosk.vue
@@ -221,7 +221,6 @@ export default {
               timer: 2000,
               showConfirmButton: false,
               type: 'success',
-              toast: this.stickToTeam,
             });
           } else {
             this.clearGTID();

--- a/resources/assets/js/components/attendance/AttendanceKiosk.vue
+++ b/resources/assets/js/components/attendance/AttendanceKiosk.vue
@@ -288,6 +288,10 @@ export default {
 </style>
 <style>
 /* Global styles */
+.swal2-checkbox {
+    font-size: 110%;
+    margin: 1.5em auto !important;
+}
 .swal2-loading {
     flex-direction: column;
 }

--- a/resources/assets/js/components/attendance/AttendanceKiosk.vue
+++ b/resources/assets/js/components/attendance/AttendanceKiosk.vue
@@ -136,7 +136,7 @@ export default {
         title: 'Swipe your BuzzCard now',
         html: event.target.innerText, // displays team name
         showCancelButton: true,
-        allowOutsideClick: true,
+        allowOutsideClick: () => !swal.isLoading(),
         showConfirmButton: false,
         imageUrl: '/img/swipe-horiz-up.gif',
         imageWidth: 450,
@@ -208,6 +208,7 @@ export default {
     submit() {
       // Submit attendance data
       this.submitting = true;
+      swal.showLoading();
       axios
         .post(this.attendanceBaseUrl, this.attendance)
         .then(response => {
@@ -223,7 +224,6 @@ export default {
               toast: this.stickToTeam,
             });
           } else {
-            swal.hideLoading();
             this.clearGTID();
           }
         })
@@ -248,10 +248,8 @@ export default {
         })
         .finally(() => {
           this.submitting = false;
+          swal.hideLoading();
         });
-      if (this.stickToTeam) {
-        swal.showLoading();
-      }
     },
     clearFields() {
       //Remove focus from button
@@ -286,5 +284,14 @@ export default {
   display: flex;
   justify-content: center;
   align-items: center;
+}
+</style>
+<style>
+/* Global styles */
+.swal2-loading {
+    flex-direction: column;
+}
+.swal2-loading button {
+    margin-bottom: 2em !important;
 }
 </style>

--- a/resources/assets/js/components/attendance/AttendanceKiosk.vue
+++ b/resources/assets/js/components/attendance/AttendanceKiosk.vue
@@ -30,6 +30,7 @@ export default {
       teamsBaseUrl: '/api/v1/teams',
       teams: [],
       stickToTeam: false,
+      submitting: false,
     };
   },
   mounted() {
@@ -102,6 +103,9 @@ export default {
       window.addEventListener(
         'keypress',
         function(e) {
+          if (this.submitting) {
+            return;
+          }
           if (this.attendance.attendable_id == '' && e.key == 'Enter') {
             //Enter was pressed but a team was not picked
             buffer = '';
@@ -204,6 +208,7 @@ export default {
     },
     submit() {
       // Submit attendance data
+      this.submitting = true;
       axios
         .post(this.attendanceBaseUrl, this.attendance)
         .then(response => {
@@ -241,6 +246,9 @@ export default {
               'error'
             );
           }
+        })
+        .finally(() => {
+          this.submitting = false;
         });
       if (this.stickToTeam) {
         swal.showLoading();

--- a/resources/assets/js/components/attendance/AttendanceKiosk.vue
+++ b/resources/assets/js/components/attendance/AttendanceKiosk.vue
@@ -12,6 +12,9 @@
 </template>
 
 <script>
+function checkboxEventListener(e) {
+  this.stickToTeam = e.target.checked;
+}
 export default {
   data() {
     return {
@@ -25,6 +28,7 @@ export default {
       attendanceBaseUrl: '/api/v1/attendance',
       teamsBaseUrl: '/api/v1/teams',
       teams: [],
+      stickToTeam: false,
     };
   },
   mounted() {
@@ -125,19 +129,24 @@ export default {
       self.attendance.attendable_id = event.target.id;
       swal({
         title: 'Swipe your BuzzCard now',
-        html: event.target.innerText,
+        html: event.target.innerText, // displays team name
         showCancelButton: true,
         closeOnCancel: false,
         allowOutsideClick: true,
         showConfirmButton: false,
         imageUrl: '/img/swipe-horiz-up.gif',
         imageWidth: 450,
+        input: 'checkbox',
+        inputValue: 0,
+        inputPlaceholder: 'Stick to this team'
       }).then(result => {
+        swal.getInput().removeEventListener("change", checkboxEventListener)
         if (!result.value) {
           self.clearFields();
           swal.close();
         }
       });
+      swal.getInput().addEventListener("change", checkboxEventListener.bind(this));
     },
     cardPresented: function(cardData) {
       // Card is presented, process the data

--- a/resources/assets/js/components/attendance/AttendanceKiosk.vue
+++ b/resources/assets/js/components/attendance/AttendanceKiosk.vue
@@ -134,6 +134,7 @@ export default {
       swal(this.getTeamSwalConfig(event.target.innerText));
     },
     getTeamSwalConfig: function(teamName) {
+      // This method pulls from state (attendance.attendable_id) when teamName is not passed (or undefined)
       if (teamName === undefined) {
         const targetTeams = this.teams.filter(team => team.id === this.attendance.attendable_id);
         if (targetTeams.length === 1) {

--- a/resources/assets/js/components/attendance/AttendanceKiosk.vue
+++ b/resources/assets/js/components/attendance/AttendanceKiosk.vue
@@ -225,7 +225,7 @@ export default {
           swal({
             title: "You're in!",
             text: 'Nice to see you, ' + response.data.attendance.name + '.',
-            timer: 2000,
+            timer: 1000,
             showConfirmButton: false,
             type: 'success',
           }).then(() => {

--- a/resources/assets/js/components/attendance/AttendanceKiosk.vue
+++ b/resources/assets/js/components/attendance/AttendanceKiosk.vue
@@ -130,11 +130,19 @@ export default {
       //Remove focus from button
       document.activeElement.blur();
       // When a team button is clicked, show a prompt to swipe BuzzCard
-      let self = this;
-      self.attendance.attendable_id = event.target.id;
-      swal({
+      this.attendance.attendable_id = event.target.id;
+      swal(this.getTeamSwalConfig(event.target.id, event.target.innerText));
+    },
+    getTeamSwalConfig: function(teamId, teamName) {
+      if (teamName === undefined) {
+        const targetTeams = this.teams.filter(team => team.id === teamId);
+        if (targetTeams.length === 1) {
+          teamName = targetTeams[0].name;
+        }
+      }
+      return {
         title: 'Swipe your BuzzCard now',
-        html: event.target.innerText, // displays team name
+        html: teamName, // displays team name
         showCancelButton: true,
         allowOutsideClick: () => !swal.isLoading(),
         showConfirmButton: false,
@@ -152,7 +160,7 @@ export default {
           swal.getInput().removeEventListener("change", checkboxEventListener);
           this.clearFields();
         }
-      })
+      }
     },
     cardPresented: function(cardData) {
       // Card is presented, process the data
@@ -213,15 +221,19 @@ export default {
         .post(this.attendanceBaseUrl, this.attendance)
         .then(response => {
           this.hasError = false;
+          swal({
+            title: "You're in!",
+            text: 'Nice to see you, ' + response.data.attendance.name + '.',
+            timer: 2000,
+            showConfirmButton: false,
+            type: 'success',
+          }).then(() => {
+            if (this.stickToTeam) {
+              swal(this.getTeamSwalConfig(this.attendance.attendable_id));
+            }
+          });
           if (!this.stickToTeam) {
             this.clearFields();
-            swal({
-              title: "You're in!",
-              text: 'Nice to see you, ' + response.data.attendance.name + '.',
-              timer: 2000,
-              showConfirmButton: false,
-              type: 'success',
-            });
           } else {
             this.clearGTID();
           }


### PR DESCRIPTION
Fixes #504 

This PR implements a "fast-read" option for the attendance kiosk by adding a checkbox that when checked will not reset the stored team ID upon successful swipes. 

This PR also improves the attendance UI by adding loaders during submit requests and prevents multiple swipes from being processed at the same time. 

**NOTE:** When a fast-read swipe is successful, the loading indicator disappears. (If no error modal appears then the swipe is successful)