### PR TITLE
nova: remove sorting for relationship columns

### DIFF
--- a/app/Nova/Attendance.php
+++ b/app/Nova/Attendance.php
@@ -77,18 +77,15 @@ class Attendance extends Resource
                 ->sortable()
                 ->rules('required', 'max:255'),
 
-            BelongsTo::make('User', 'attendee')
-                ->sortable(),
+            BelongsTo::make('User', 'attendee'),
 
             MorphTo::make('Attended', 'attendable')
-                ->sortable()
                 ->types([
                     Event::class,
                     Team::class,
                 ]),
 
             (new BelongsTo('Recorded By', 'recorded', 'App\Nova\User'))
-                ->sortable()
                 ->help('The user that recorded the swipe'),
 
             DateTime::make('Time', 'created_at')

--- a/app/Nova/Event.php
+++ b/app/Nova/Event.php
@@ -64,7 +64,6 @@ class Event extends Resource
 
             (new BelongsTo('Organizer', 'organizer', 'App\Nova\User'))
                 ->searchable()
-                ->sortable()
                 ->rules('required')
                 // default to self
                 ->help('The organizer of the event'),

--- a/app/Nova/Rsvp.php
+++ b/app/Nova/Rsvp.php
@@ -71,11 +71,9 @@ class Rsvp extends Resource
     protected function basicFields()
     {
         return [
-            BelongsTo::make('User')
-                ->sortable(),
+            BelongsTo::make('User'),
 
-            BelongsTo::make('Event')
-                ->sortable(),
+            BelongsTo::make('Event'),
 
             Text::make('Response')
                 ->sortable(),


### PR DESCRIPTION
Nova does not automatically join relationships when sorting by a relationship column.

This PR removes sorting from these columns but it might also be feasible to override the indexQuery static method for each resource.

Fixes #519.