### PR TITLE
Reports tweaks

### DIFF
--- a/app/Nova/Lenses/RecentInactiveUsers.php
+++ b/app/Nova/Lenses/RecentInactiveUsers.php
@@ -42,14 +42,11 @@ class RecentInactiveUsers extends Lens
     public function fields(Request $request)
     {
         return [
-            Text::make('GTID')
-                ->sortable(),
+            Text::make('GTID'),
 
-            BelongsTo::make('User', 'attendee', 'App\Nova\User')
-                ->sortable(),
+            BelongsTo::make('User', 'attendee', 'App\Nova\User'),
 
             MorphTo::make('Attended', 'attendable')
-                ->sortable()
                 ->types([
                     Event::class,
                     Team::class,

--- a/app/Nova/Metrics/AttendancePerWeek.php
+++ b/app/Nova/Metrics/AttendancePerWeek.php
@@ -35,7 +35,7 @@ class AttendancePerWeek extends Trend
 
         // Aggregate based on counting distinct values in the gtid column
         $column = DB::raw('distinct attendance.gtid');
-        $result = $this->aggregate($request, $query, Trend::BY_WEEKS, 'count', $column, 'created_at');
+        $result = $this->aggregate($request, $query, Trend::BY_WEEKS, 'count', $column, 'created_at')->showLatestValue();
 
         $request->timezone = $originalTimezone;
 

--- a/app/Nova/Metrics/PaymentMethodBreakdown.php
+++ b/app/Nova/Metrics/PaymentMethodBreakdown.php
@@ -24,6 +24,7 @@ class PaymentMethodBreakdown extends Partition
     public function calculate(Request $request)
     {
         return $this->result(Payment::where('payable_type', 'App\DuesTransaction')
+            ->where('amount', '>', 0)
             ->whereIn('payable_id', function ($q) use ($request) {
                 $q->select('id')
                     ->from('dues_transactions')

--- a/app/Nova/Metrics/RsvpSourceBreakdown.php
+++ b/app/Nova/Metrics/RsvpSourceBreakdown.php
@@ -13,7 +13,7 @@ class RsvpSourceBreakdown extends Partition
      *
      * @var string
      */
-    public $name = 'RSVP Source Breakdown';
+    public $name = 'RSVP Sources';
 
     /**
      * Calculate the value of the metric.


### PR DESCRIPTION
Fix  #526, fix #527, and shorten the RSVP Sources Breakdown metric name to RSVP Sources so it doesn't wrap with >=100 items in the count.