### PR TITLE
Fix Nova having sideways scroll

### DIFF
--- a/resources/assets/css/nova.css
+++ b/resources/assets/css/nova.css
@@ -3,4 +3,5 @@
 }
 #nova .content {
     max-width: calc(100vw - 14.75rem);
+    min-width: 65.25rem;
 }


### PR DESCRIPTION
The min-width was originally hard-coded in Nova's stylesheet to 66.25rem, and when I widened the sidebar by 1rem so it didn't wrap "Notification Templates" (#488) I didn't update the min-width accordingly.