### PR TITLE
Fix #536

### DIFF
--- a/resources/assets/js/components/nova/AttendanceReport.vue
+++ b/resources/assets/js/components/nova/AttendanceReport.vue
@@ -104,8 +104,11 @@ export default {
           }),
         ],
       },
-      selectedRange: 52,
+      selectedRange: 8,
       ranges: [
+        2,
+        4,
+        8,
         12,
         26,
         52,


### PR DESCRIPTION
Add 2, 4, and 8 week range options, with 8 selected by default, to the attendance report.