### PR TITLE
(#400) Add team column to Dues/Swag datatables

### DIFF
--- a/app/DuesTransaction.php
+++ b/app/DuesTransaction.php
@@ -119,6 +119,7 @@ class DuesTransaction extends Model
             'user' => 'users',
             'package' => 'dues-packages',
             'payment' => 'payments',
+            'user.teams' => 'teams-membership',
         ];
     }
 

--- a/resources/assets/js/components/wrappers/DuesAdminTable.vue
+++ b/resources/assets/js/components/wrappers/DuesAdminTable.vue
@@ -27,7 +27,7 @@ export default {
         { title: 'Status', data: 'status', className: 'text-capitalize' },
         { title: 'Amount Paid', data: 'payment[0].amount' },
         { title: 'Payment Method', data: 'payment[0].method', className: 'text-capitalize' },
-        { title: 'Date Paid', data: 'payment[0].created_at' },
+        { title: 'Date Paid', data: 'payment[0].created_at.date' },
       ],
     };
   },

--- a/resources/assets/js/components/wrappers/DuesAdminTable.vue
+++ b/resources/assets/js/components/wrappers/DuesAdminTable.vue
@@ -22,7 +22,7 @@ export default {
               return "N/A";
             }
             return teams.join(", ");
-          }},
+        }},
         { title: 'Dues Package', data: 'package.name' },
         { title: 'Status', data: 'status', className: 'text-capitalize' },
         { title: 'Amount Paid', data: 'payment[0].amount' },

--- a/resources/assets/js/components/wrappers/DuesAdminTable.vue
+++ b/resources/assets/js/components/wrappers/DuesAdminTable.vue
@@ -19,7 +19,7 @@ export default {
               return team.name;
             });
             if (teams.length === 0) {
-              return "N/A";
+              return "None";
             }
             return teams.join(", ");
         }},

--- a/resources/assets/js/components/wrappers/DuesAdminTable.vue
+++ b/resources/assets/js/components/wrappers/DuesAdminTable.vue
@@ -1,6 +1,6 @@
 <template>
   <datatable id="dues-admin-table"
-    data-url="/api/v1/dues/transactions?include=user,payment"
+    data-url="/api/v1/dues/transactions?include=user,payment,user.teams"
     data-path="dues_transactions"
     :columns="tableConfig">
   </datatable>
@@ -14,6 +14,15 @@ export default {
         { title: 'ID', data: 'id' },
         { title: 'Timestamp', data: 'created_at.date' },
         { title: 'Name', data: 'user.name' },
+        { title: 'Teams', data: function(row) {
+            const teams = row.user.teams.map(function(team) {
+              return team.name;
+            });
+            if (teams.length === 0) {
+              return "N/A";
+            }
+            return teams.join(", ");
+          }},
         { title: 'Dues Package', data: 'package.name' },
         { title: 'Status', data: 'status', className: 'text-capitalize' },
         { title: 'Amount Paid', data: 'payment[0].amount' },

--- a/resources/assets/js/components/wrappers/PendingDuesTable.vue
+++ b/resources/assets/js/components/wrappers/PendingDuesTable.vue
@@ -20,7 +20,7 @@ export default {
               return team.name;
             });
             if (teams.length === 0) {
-              return "N/A";
+              return "None";
             }
             return teams.join(", ");
         }},

--- a/resources/assets/js/components/wrappers/PendingDuesTable.vue
+++ b/resources/assets/js/components/wrappers/PendingDuesTable.vue
@@ -1,6 +1,6 @@
 <template>
   <datatable id="dues-admin-table"
-    data-url="/api/v1/dues/transactions/pending?include=user"
+    data-url="/api/v1/dues/transactions/pending?include=user,user.teams"
     data-path="dues_transactions"
     data-link="/admin/dues/"
     :columns="tableConfig">
@@ -15,6 +15,15 @@ export default {
         { title: 'ID', data: 'id' },
         { title: 'Timestamp', data: 'updated_at.date' },
         { title: 'Name', data: 'user.name' },
+        { title: 'Teams', data: function(row) {
+            const teams = row.user.teams.map(function(team) {
+              return team.name;
+            });
+            if (teams.length === 0) {
+              return "N/A";
+            }
+            return teams.join(", ");
+          }},
         { title: 'Dues Package', data: 'package.name' },
       ],
     };

--- a/resources/assets/js/components/wrappers/PendingDuesTable.vue
+++ b/resources/assets/js/components/wrappers/PendingDuesTable.vue
@@ -23,7 +23,7 @@ export default {
               return "N/A";
             }
             return teams.join(", ");
-          }},
+        }},
         { title: 'Dues Package', data: 'package.name' },
       ],
     };

--- a/resources/assets/js/components/wrappers/SwagTable.vue
+++ b/resources/assets/js/components/wrappers/SwagTable.vue
@@ -1,14 +1,14 @@
 <template>
   <datatable v-if="this.tableFilter == 'index'"
              id="swag-index-table" 
-             data-url="/api/v1/dues/transactions/paid?include=user"
+             data-url="/api/v1/dues/transactions/paid?include=user,user.teams"
              data-path="dues_transactions"
              data-link="/admin/swag/"
              :columns="tableConfig">
   </datatable>
   <datatable v-else-if="this.tableFilter == 'pending'"
              id="swag-pending-table"
-             data-url="/api/v1/dues/transactions/pendingSwag?include=user"
+             data-url="/api/v1/dues/transactions/pendingSwag?include=user,user.teams"
              data-path="dues_transactions"
              data-link="/admin/swag/"
              :columns="tableConfig">
@@ -27,6 +27,15 @@ export default {
       tableConfig: [
         { title: 'ID', data: 'id' },
         { title: 'Name', data: 'user.name' },
+        { title: 'Teams', data: function(row) {
+            const teams = row.user.teams.map(function(team) {
+              return team.name;
+            });
+            if (teams.length === 0) {
+              return "N/A";
+            }
+            return teams.join(", ");
+        }},
         { title: 'Dues Package', data: 'package.name' },
         { title: 'Shirt', data: 'swag_shirt_status' },
         { title: 'Polo', data: 'swag_polo_status' },

--- a/resources/assets/js/components/wrappers/SwagTable.vue
+++ b/resources/assets/js/components/wrappers/SwagTable.vue
@@ -32,7 +32,7 @@ export default {
               return team.name;
             });
             if (teams.length === 0) {
-              return "N/A";
+              return "None";
             }
             return teams.join(", ");
         }},


### PR DESCRIPTION
This PR fixes #400 by adding a team column to the dues/swag datatables. It also fixes a date field problem caused by the new API changes in `DuesAdminTable`.