### PR TITLE
Update user using validated fields

### DIFF
--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -181,7 +181,7 @@ class UserController extends Controller
         }
 
         //Update only included fields
-        $this->validate($request, [
+        $validatedFields = $this->validate($request, [
             'slack_id' => ['max:21', 'nullable', Rule::unique('users')->ignore($user->id)],
             'personal_email' => ['max:255', 'nullable', Rule::unique('users')->ignore($user->id)],
             'middle_name' => 'max:127',
@@ -208,7 +208,7 @@ class UserController extends Controller
         }
         unset($request['generateToken']);
 
-        $user->update($request->all());
+        $user->update($validatedFields);
 
         if ($request->filled('roles')) {
             $user->roles()->sync($request->input('roles'));

--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -184,6 +184,8 @@ class UserController extends Controller
         $validatedFields = $this->validate($request, [
             'slack_id' => ['max:21', 'nullable', Rule::unique('users')->ignore($user->id)],
             'personal_email' => ['max:255', 'nullable', Rule::unique('users')->ignore($user->id)],
+            'first_name'=> 'max:127',
+            'last_name' => 'max:127',
             'middle_name' => 'max:127',
             'preferred_name' => 'max:127',
             'phone' => 'max:15',
@@ -195,6 +197,8 @@ class UserController extends Controller
             'polo_size' => 'in:s,m,l,xl,xxl,xxxl|nullable',
             'accept_safety_agreement => date|nullable',
             'generateToken' => 'boolean',
+            'gender' => 'string|nullable',
+            'ethnicity' => 'string|nullable',
         ]);
 
         //Generate an API token for the user if requested *AND* the requesting user is self or admin


### PR DESCRIPTION
This PR patches the error caused by [this exception](https://app.bugsnag.com/robojackets/apiary/errors/5c3939978249de001bffa644?event_id=5c3aa3860032c02c43cc0000&i=sk&m=oc) that is caused by invalid date fields by updating the user document using only fields that have been validated.