### PR TITLE
Create Nova "Hidden" field type for GTIDs and API keys

### DIFF
--- a/app/Nova/Fields/Hidden.php
+++ b/app/Nova/Fields/Hidden.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Nova\Fields;
+
+use Laravel\Nova\Fields\Field;
+
+class Hidden extends Field
+{
+    /**
+     * The field's component.
+     *
+     * @var string
+     */
+    public $component = 'hidden-field';
+
+    /**
+     * Set a monospaced font
+     *
+     * @return $this
+     */
+    public function monospaced()
+    {
+        return $this->withMeta(['monospaced' => true]);
+    }
+}

--- a/app/Nova/Fields/Hidden.php
+++ b/app/Nova/Fields/Hidden.php
@@ -14,7 +14,7 @@ class Hidden extends Field
     public $component = 'hidden-field';
 
     /**
-     * Set a monospaced font
+     * Set a monospaced font.
      *
      * @return $this
      */

--- a/app/Nova/User.php
+++ b/app/Nova/User.php
@@ -3,6 +3,7 @@
 namespace App\Nova;
 
 use Laravel\Nova\Panel;
+use App\Nova\Fields\Hidden;
 use Illuminate\Http\Request;
 use Laravel\Nova\Fields\Text;
 use Laravel\Nova\Fields\Number;
@@ -85,7 +86,7 @@ class User extends Resource
                 ->creationRules('unique:users,personal_email')
                 ->updateRules('unique:users,personal_email,{{resourceId}}'),
 
-            Number::make('GTID')
+            Hidden::make('GTID')
                 ->onlyOnDetail()
                 ->hideWhenCreating()
                 ->hideWhenUpdating()
@@ -93,8 +94,9 @@ class User extends Resource
                     return $request->user()->can('read-users-gtid');
                 }),
 
-            Text::make('API Token')
+            Hidden::make('API Token')
                 ->onlyOnDetail()
+                ->monospaced()
                 ->canSee(function ($request) {
                     if ($request->resourceId == $request->user()->id) {
                         return true;

--- a/resources/assets/js/components/nova/HiddenFieldDetail.vue
+++ b/resources/assets/js/components/nova/HiddenFieldDetail.vue
@@ -14,9 +14,9 @@
 export default {
     props: [ 'resource', 'resourceName', 'resourceId', 'field' ],
 
-    data: () => {
+    data: () => ({
         expanded: false
-    },
+    }),
 
     methods: {
         toggle() {

--- a/resources/assets/js/components/nova/HiddenFieldDetail.vue
+++ b/resources/assets/js/components/nova/HiddenFieldDetail.vue
@@ -1,0 +1,33 @@
+<template>
+    <panel-item :field="field">
+        <template slot="value">
+            <div v-if="hasContent">
+                <p v-if="expanded" class="text-90 inline" :class="{ 'font-mono': field.monospaced }">{{ field.value }}</p>
+                <a @click="toggle" class="cursor-pointer dim inline text-primary font-bold" :class="{ 'mt-6': expanded }" aria-role="button">{{ this.expanded ? 'Hide' : 'Show' }}</a>
+            </div>
+            <div v-else>&mdash;</div>
+        </template>
+    </panel-item>
+</template>
+
+<script>
+export default {
+    props: [ 'resource', 'resourceName', 'resourceId', 'field' ],
+
+    data: () => {
+        expanded: false
+    },
+
+    methods: {
+        toggle() {
+            this.expanded = !this.expanded;
+        },
+    },
+
+    computed: {
+        hasContent() {
+            return this.field.value !== '' && this.field.value !== null;
+        },
+    },
+}
+</script>

--- a/resources/assets/js/nova.js
+++ b/resources/assets/js/nova.js
@@ -1,5 +1,6 @@
 Nova.booting((Vue, router) => {
     Vue.component('makeawish', require('./components/nova/MakeAWishCard.vue'));
+    Vue.component('detail-hidden-field', require('./components/nova/HiddenFieldDetail.vue'));
 
     router.addRoutes([
         {


### PR DESCRIPTION
Hide GTIDs and API keys by default on user pages. Also fixes #601 by showing API keys in a monospaced font.
<img width="334" alt="image" src="https://user-images.githubusercontent.com/291371/56513514-c02b9d80-6500-11e9-9339-de74aa4e9ee5.png">