### PR TITLE
Use reason 'manual_batch' for Nova JEDI sync for >1 user

### DIFF
--- a/app/Nova/Actions/SyncAccess.php
+++ b/app/Nova/Actions/SyncAccess.php
@@ -38,7 +38,12 @@ class SyncAccess extends Action
 
             // I tried to make this class ShouldQueue so Nova would handle queueing
             // but was getting an exception. I think it's fine to run synchronously...?
-            PushToJedi::dispatchNow($user, self::class, request()->user()->id, 'manual');
+            PushToJedi::dispatchNow(
+                $user,
+                self::class,
+                request()->user()->id,
+                count($models) === 1 ? 'manual' : 'manual_batch'
+            );
         }
     }
 

--- a/app/Nova/Actions/SyncAccess.php
+++ b/app/Nova/Actions/SyncAccess.php
@@ -42,7 +42,7 @@ class SyncAccess extends Action
                 $user,
                 self::class,
                 request()->user()->id,
-                count($models) === 1 ? 'manual' : 'manual_batch'
+                1 === count($models) ? 'manual' : 'manual_batch'
             );
         }
     }


### PR DESCRIPTION
This will allow JEDI to cache requests as usual for mass syncs while still allowing admins to skip the cache for single user syncs.