### PR TITLE
Deployment improvements

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,6 +1,6 @@
 root = true
 
-[*.php]
+[*]
 end_of_line = lf
 insert_final_newline = true
 indent_style = space
@@ -8,15 +8,7 @@ indent_size = 4
 trim_trailing_whitespace = true
 
 [*.neon]
-end_of_line = lf
-insert_final_newline = true
-indent_style = space
 indent_size = 2
-trim_trailing_whitespace = true
 
 [*.yml]
-end_of_line = lf
-insert_final_newline = true
-indent_style = space
 indent_size = 2
-trim_trailing_whitespace = true

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -8,6 +8,7 @@ use App\Jobs\DailyDuesSummary;
 use App\Jobs\WeeklyAttendance;
 use App\Jobs\NoAttendanceJediPush;
 use Illuminate\Console\Scheduling\Schedule;
+use Bugsnag\BugsnagLaravel\Commands\DeployCommand;
 use Illuminate\Foundation\Console\Kernel as ConsoleKernel;
 
 class Kernel extends ConsoleKernel
@@ -17,7 +18,9 @@ class Kernel extends ConsoleKernel
      *
      * @var array<string>
      */
-    protected $commands = [];
+    protected $commands = [
+        DeployCommand::class
+    ];
 
     /**
      * Define the application's command schedule.

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -19,7 +19,7 @@ class Kernel extends ConsoleKernel
      * @var array<string>
      */
     protected $commands = [
-        DeployCommand::class
+        DeployCommand::class,
     ];
 
     /**

--- a/config/bugsnag.php
+++ b/config/bugsnag.php
@@ -186,7 +186,7 @@ return [
     |
     */
 
-    'notify_release_stages' => env('BUGSNAG_NOTIFY_RELEASE_STAGES') ?? : explode(
+    'notify_release_stages' => env('BUGSNAG_NOTIFY_RELEASE_STAGES') ?? explode(
         ',',
         str_replace(' ', '', env('BUGSNAG_NOTIFY_RELEASE_STAGES'))
     ),

--- a/config/bugsnag.php
+++ b/config/bugsnag.php
@@ -1,0 +1,278 @@
+<?php
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | API Key
+    |--------------------------------------------------------------------------
+    |
+    | You can find your API key on your Bugsnag dashboard.
+    |
+    | This api key points the Bugsnag notifier to the project in your account
+    | which should receive your application's uncaught exceptions.
+    |
+    */
+
+    'api_key' => env('BUGSNAG_API_KEY', ''),
+
+    /*
+    |--------------------------------------------------------------------------
+    | App Type
+    |--------------------------------------------------------------------------
+    |
+    | Set the type of application executing the current code.
+    |
+    */
+
+    'app_type' => env('BUGSNAG_APP_TYPE'),
+
+    /*
+    |--------------------------------------------------------------------------
+    | App Version
+    |--------------------------------------------------------------------------
+    |
+    | Set the version of application executing the current code.
+    |
+    */
+
+    'app_version' => exec('cd ' . __DIR__ . ' && git rev-parse HEAD'),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Batch Sending
+    |--------------------------------------------------------------------------
+    |
+    | Set to true to send the errors through to Bugsnag when the PHP process
+    | shuts down, in order to prevent your app waiting on HTTP requests.
+    |
+    | Setting this to false will send an HTTP request straight away for each
+    | error.
+    |
+    */
+
+    'batch_sending' => env('BUGSNAG_BATCH_SENDING'),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Endpoint
+    |--------------------------------------------------------------------------
+    |
+    | Set what server the Bugsnag notifier should send errors to. By default
+    | this is set to 'https://notify.bugsnag.com', but for Bugsnag Enterprise
+    | this should be the URL to your Bugsnag instance.
+    |
+    */
+
+    'endpoint' => env('BUGSNAG_ENDPOINT'),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Filters
+    |--------------------------------------------------------------------------
+    |
+    | Use this if you want to ensure you don't send sensitive data such as
+    | passwords, and credit card numbers to our servers. Any keys which
+    | contain these strings will be filtered.
+    |
+    */
+
+    'filters' => empty(env('BUGSNAG_FILTERS')) ? ['password'] : explode(',', str_replace(' ', '', env('BUGSNAG_FILTERS'))),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Hostname
+    |--------------------------------------------------------------------------
+    |
+    | You can set the hostname of your server to something specific for you to
+    | identify it by if needed.
+    |
+    */
+
+    'hostname' => env('BUGSNAG_HOSTNAME'),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Proxy
+    |--------------------------------------------------------------------------
+    |
+    | This is where you can set the proxy settings you'd like us to use when
+    | communicating with Bugsnag when reporting errors.
+    |
+    */
+
+    'proxy' => array_filter([
+        'http' => env('HTTP_PROXY'),
+        'https' => env('HTTPS_PROXY'),
+        'no' => empty(env('NO_PROXY')) ? null : explode(',', str_replace(' ', '', env('NO_PROXY'))),
+    ]),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Project Root
+    |--------------------------------------------------------------------------
+    |
+    | Bugsnag marks stacktrace lines as in-project if they come from files
+    | inside your “project root”. You can set this here.
+    |
+    | If this is not set, we will automatically try to detect it.
+    |
+    */
+
+    'project_root' => env('BUGSNAG_PROJECT_ROOT'),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Strip Path
+    |--------------------------------------------------------------------------
+    |
+    | You can set a strip path to have it also trimmed from the start of any
+    | filepath in your stacktraces.
+    |
+    | If this is not set, we will automatically try to detect it.
+    |
+    */
+
+    'strip_path' => env('BUGSNAG_STRIP_PATH'),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Query
+    |--------------------------------------------------------------------------
+    |
+    | Enable this if you'd like us to automatically record all queries executed
+    | as breadcrumbs.
+    |
+    */
+
+    'query' => env('BUGSNAG_QUERY', true),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Bindings
+    |--------------------------------------------------------------------------
+    |
+    | Enable this if you'd like us to include the query bindings in our query
+    | breadcrumbs.
+    |
+    */
+
+    'bindings' => env('BUGSNAG_QUERY_BINDINGS', false),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Release Stage
+    |--------------------------------------------------------------------------
+    |
+    | Set the release stage to use when sending notifications to Bugsnag.
+    |
+    | Leaving this unset will default to using the application environment.
+    |
+    */
+
+    'release_stage' => env('BUGSNAG_RELEASE_STAGE'),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Notify Release Stages
+    |--------------------------------------------------------------------------
+    |
+    | Set which release stages should send notifications to Bugsnag.
+    |
+    */
+
+    'notify_release_stages' => empty(env('BUGSNAG_NOTIFY_RELEASE_STAGES')) ? null : explode(',', str_replace(' ', '', env('BUGSNAG_NOTIFY_RELEASE_STAGES'))),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Send Code
+    |--------------------------------------------------------------------------
+    |
+    | Bugsnag automatically sends a small snippet of the code that crashed to
+    | help you diagnose even faster from within your dashboard. If you don’t
+    | want to send this snippet, then set this to false.
+    |
+    */
+
+    'send_code' => env('BUGSNAG_SEND_CODE', true),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Callbacks
+    |--------------------------------------------------------------------------
+    |
+    | Enable this if you'd like us to enable our default set of notification
+    | callbacks. These add things like the cookie information and session
+    | details to the error to be sent to Bugsnag.
+    |
+    | If you'd like to add your own callbacks, you can call the
+    | Bugsnag::registerCallback method from the boot method of your app
+    | service provider.
+    |
+    */
+
+    'callbacks' => env('BUGSNAG_CALLBACKS', true),
+
+    /*
+    |--------------------------------------------------------------------------
+    | User
+    |--------------------------------------------------------------------------
+    |
+    | Enable this if you'd like us to set the current user logged in via
+    | Laravel's authentication system.
+    |
+    | If you'd like to add your own user resolver, you can do this by using
+    | callbacks via Bugsnag::registerCallback.
+    |
+    */
+
+    'user' => env('BUGSNAG_USER', true),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Logger Notify Level
+    |--------------------------------------------------------------------------
+    |
+    | This sets the level at which a logged message will trigger a notification
+    | to Bugsnag.  By default this level will be 'notice'.
+    |
+    | Must be one of the Psr\Log\LogLevel levels from the Psr specification.
+    |
+    */
+
+    'logger_notify_level' => env('BUGSNAG_LOGGER_LEVEL'),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Auto Capture Sessions
+    |--------------------------------------------------------------------------
+    |
+    | Enable this to start tracking sessions and deliver them to Bugsnag.
+    |
+    */
+
+    'auto_capture_sessions' => env('BUGSNAG_CAPTURE_SESSIONS', false),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Sessions Endpoint
+    |--------------------------------------------------------------------------
+    |
+    | Sets a url to send tracked sessions to.
+    |
+    */
+
+    'session_endpoint' => env('BUGSNAG_SESSION_ENDPOINT'),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Builds Endpoint
+    |--------------------------------------------------------------------------
+    |
+    | Sets a url to send build reports to.
+    |
+    */
+
+    'build_endpoint' => env('BUGSNAG_BUILD_ENDPOINT'),
+
+];

--- a/config/bugsnag.php
+++ b/config/bugsnag.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 return [
 
     /*
@@ -36,7 +38,7 @@ return [
     |
     */
 
-    'app_version' => exec('cd ' . __DIR__ . ' && git rev-parse HEAD'),
+    'app_version' => exec('cd '.__DIR__.' && git rev-parse HEAD'),
 
     /*
     |--------------------------------------------------------------------------
@@ -77,7 +79,10 @@ return [
     |
     */
 
-    'filters' => empty(env('BUGSNAG_FILTERS')) ? ['password'] : explode(',', str_replace(' ', '', env('BUGSNAG_FILTERS'))),
+    'filters' => env('BUGSNAG_FILTERS') === null ? ['password'] : explode(
+        ',',
+        str_replace(' ', '', env('BUGSNAG_FILTERS'))
+    ),
 
     /*
     |--------------------------------------------------------------------------
@@ -104,7 +109,7 @@ return [
     'proxy' => array_filter([
         'http' => env('HTTP_PROXY'),
         'https' => env('HTTPS_PROXY'),
-        'no' => empty(env('NO_PROXY')) ? null : explode(',', str_replace(' ', '', env('NO_PROXY'))),
+        'no' => env('NO_PROXY') ?? explode(',', str_replace(' ', '', env('NO_PROXY'))),
     ]),
 
     /*
@@ -181,7 +186,10 @@ return [
     |
     */
 
-    'notify_release_stages' => empty(env('BUGSNAG_NOTIFY_RELEASE_STAGES')) ? null : explode(',', str_replace(' ', '', env('BUGSNAG_NOTIFY_RELEASE_STAGES'))),
+    'notify_release_stages' => env('BUGSNAG_NOTIFY_RELEASE_STAGES') ?? : explode(
+        ',',
+        str_replace(' ', '', env('BUGSNAG_NOTIFY_RELEASE_STAGES'))
+    ),
 
     /*
     |--------------------------------------------------------------------------

--- a/config/bugsnag.php
+++ b/config/bugsnag.php
@@ -79,7 +79,7 @@ return [
     |
     */
 
-    'filters' => env('BUGSNAG_FILTERS') === null ? ['password'] : explode(
+    'filters' => null === env('BUGSNAG_FILTERS') ? ['password'] : explode(
         ',',
         str_replace(' ', '', env('BUGSNAG_FILTERS'))
     ),

--- a/post-deploy-hook.sh
+++ b/post-deploy-hook.sh
@@ -25,3 +25,5 @@ fi
 php artisan up
 php artisan horizon:terminate
 php artisan bugsnag:deploy --repository "https://github.com/RoboJackets/apiary" --revision $(git rev-parse HEAD) --builder "rj-dc-00"
+
+./resume-monitoring.sh

--- a/post-deploy-hook.sh
+++ b/post-deploy-hook.sh
@@ -10,7 +10,18 @@ php artisan route:clear --no-interaction
 php artisan nova:publish --no-interaction
 php artisan horizon:assets --no-interaction
 php artisan cache:clear --no-interaction
-npm ci --no-progress
-npm run production --no-progress
+
+LAST_DEPLOYMENT=$(cat .last_deployment_hash)
+THIS_DEPLOYMENT=$(git rev-parse HEAD)
+
+if [ "$LAST_DEPLOYMENT" == "" ] || [ "$THIS_DEPLOYMENT" == "$LAST_DEPLOYMENT" ] || git diff --name-only $LAST_DEPLOYMENT $THIS_DEPLOYMENT | grep -q '^package-lock\.json$'; then
+    npm ci --no-progress
+fi
+
+if [ "$LAST_DEPLOYMENT" == "" ] || [ "$THIS_DEPLOYMENT" == "$LAST_DEPLOYMENT" ] || git diff --name-only $LAST_DEPLOYMENT $THIS_DEPLOYMENT | grep -q '^package-lock\.json$' || git diff --name-only $LAST_DEPLOYMENT $THIS_DEPLOYMENT | grep -q '.+\.[js|vue]$'; then
+    npm run production --no-progress
+fi
+
 php artisan up
 php artisan horizon:terminate
+php artisan bugsnag:deploy --repository "https://github.com/RoboJackets/apiary" --revision $(git rev-parse HEAD) --builder "rj-dc-00"

--- a/pre-deploy-hook.sh
+++ b/pre-deploy-hook.sh
@@ -3,3 +3,5 @@
 cd "${0%/*}"
 
 php artisan down --message="An app upgrade is in progress. Please try again in a few minutes." --retry=60
+
+git rev-parse HEAD > .last_deployment_hash

--- a/pre-deploy-hook.sh
+++ b/pre-deploy-hook.sh
@@ -2,6 +2,8 @@
 
 cd "${0%/*}"
 
+./pause-monitoring.sh
+
 php artisan down --message="An app upgrade is in progress. Please try again in a few minutes." --retry=60
 
 git rev-parse HEAD > .last_deployment_hash


### PR DESCRIPTION
- Skip `npm ci` if no changes to `package-lock.json` since the last deployment
- Skip `npm run production` if no changes to `package-lock.json` or tracked JavaScript source files since the last deployment
- Notify Bugsnag of the deployment (closes #464)
- Send app version to Bugsnag when errors occur