### PR TITLE
Add attendance observer for Jedi pushes

### DIFF
--- a/app/Observers/AttendanceObserver.php
+++ b/app/Observers/AttendanceObserver.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Observers;
+
+use App\Attendance;
+use App\Jobs\PushToJedi;
+
+class AttendanceObserver
+{
+    public function saved(Attendance $attendance): void
+    {
+        if (null === $attendance->attendee) {
+            return;
+        }
+
+        PushToJedi::dispatch($attendance->attendee, Attendance::class, $attendance->id, 'saved')->onQueue('jedi');
+    }
+}

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -6,10 +6,12 @@ namespace App\Providers;
 
 use App\User;
 use App\Payment;
+use App\Attendance;
 use App\DuesPackage;
 use Laravel\Horizon\Horizon;
 use App\Observers\UserObserver;
 use App\Observers\PaymentObserver;
+use App\Observers\AttendanceObserver;
 use App\Observers\DuesPackageObserver;
 use Illuminate\Support\ServiceProvider;
 use Illuminate\Http\Resources\Json\Resource;
@@ -42,6 +44,7 @@ class AppServiceProvider extends ServiceProvider
 
         User::observe(UserObserver::class);
         Payment::observe(PaymentObserver::class);
+        Attendance::observe(AttendanceObserver::class);
         DuesPackage::observe(DuesPackageObserver::class);
     }
 


### PR DESCRIPTION
The existing relationship observer triggers syncs for the user who created the attendance record but not the attendee.