### PR TITLE
Add waiver payment method

### DIFF
--- a/app/Http/Requests/StorePaymentRequest.php
+++ b/app/Http/Requests/StorePaymentRequest.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace App\Http\Requests;
 
+use App\Payment;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Validation\Rule;
-use App\Payment;
 
 class StorePaymentRequest extends FormRequest
 {
@@ -23,7 +23,7 @@ class StorePaymentRequest extends FormRequest
     /**
      * Get the validation rules that apply to the request.
      *
-     * @return array<string,string>
+     * @return array<string,string|\Illuminate\Validation\Rules\In>
      */
     public function rules(): array
     {
@@ -32,7 +32,7 @@ class StorePaymentRequest extends FormRequest
             'method'       => [
                 'required',
                 'string',
-                Rule::in(array_keys(Payment::$method))
+                Rule::in(array_keys(Payment::$methods)),
             ],
             'recorded_by'  => 'required|numeric|exists:users,id',
             'payable_type' => 'required|string',

--- a/app/Http/Requests/StorePaymentRequest.php
+++ b/app/Http/Requests/StorePaymentRequest.php
@@ -23,7 +23,7 @@ class StorePaymentRequest extends FormRequest
     /**
      * Get the validation rules that apply to the request.
      *
-     * @return array<string,string|\Illuminate\Validation\Rules\In>
+     * @return array<string,string|array<string|\Illuminate\Validation\Rules\In>>
      */
     public function rules(): array
     {

--- a/app/Http/Requests/StorePaymentRequest.php
+++ b/app/Http/Requests/StorePaymentRequest.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace App\Http\Requests;
 
 use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+use App\Payment;
 
 class StorePaymentRequest extends FormRequest
 {
@@ -27,7 +29,11 @@ class StorePaymentRequest extends FormRequest
     {
         return [
             'amount'       => 'required|numeric',
-            'method'       => 'required|string|in:cash,check,swipe,square,squarecash',
+            'method'       => [
+                'required',
+                'string',
+                Rule::in(array_keys(Payment::$method))
+            ],
             'recorded_by'  => 'required|numeric|exists:users,id',
             'payable_type' => 'required|string',
             'payable_id'   => 'required|numeric',

--- a/app/Notifications/Dues/SummaryNotification.php
+++ b/app/Notifications/Dues/SummaryNotification.php
@@ -74,7 +74,7 @@ class SummaryNotification extends Notification
 
                 return $a->count() > $b->count() ? -1 : 1;
             })->map(static function (Collection $payment, string $method) {
-                return $payment->count().' paid with '. Payment::$methods[$method];
+                return $payment->count().' paid with '.Payment::$methods[$method];
             })->join(', ', ' and ');
         $packages = $payments->groupBy(static function (Payment $payment) {
             // We know it's a DuesTransaction because of filtering in getPayments. Include trashed because in some

--- a/app/Notifications/Dues/SummaryNotification.php
+++ b/app/Notifications/Dues/SummaryNotification.php
@@ -74,15 +74,7 @@ class SummaryNotification extends Notification
 
                 return $a->count() > $b->count() ? -1 : 1;
             })->map(static function (Collection $payment, string $method) {
-                $paymentMethods = [
-                    'cash' => 'cash',
-                    'squarecash' => 'Square Cash',
-                    'check' => 'a check',
-                    'swipe' => 'a swiped card',
-                    'square' => 'Square Checkout',
-                ];
-
-                return $payment->count().' paid with '.$paymentMethods[$method];
+                return $payment->count().' paid with '. Payment::$methods[$method];
             })->join(', ', ' and ');
         $packages = $payments->groupBy(static function (Payment $payment) {
             // We know it's a DuesTransaction because of filtering in getPayments. Include trashed because in some

--- a/app/Nova/Actions/AddPayment.php
+++ b/app/Nova/Actions/AddPayment.php
@@ -115,17 +115,9 @@ class AddPayment extends Action
      */
     public function fields(): array
     {
-        $payment_methods = [
-            'cash' => 'Cash',
-            'squarecash' => 'Square Cash',
-            'check' => 'Check',
-            'swipe' => 'Swiped Card',
-            'square' => 'Square Checkout',
-        ];
-
         $allowed_payment_methods = [];
 
-        foreach ($payment_methods as $code => $display) {
+        foreach (Payment::$methods as $code => $display) {
             if (Auth::user()->cant('create-payments-'.$code)) {
                 continue;
             }

--- a/app/Nova/Metrics/PaymentMethodBreakdown.php
+++ b/app/Nova/Metrics/PaymentMethodBreakdown.php
@@ -43,7 +43,7 @@ class PaymentMethodBreakdown extends Partition
                     ->orderBy('aggregate', 'desc')
                     ->get()
                     ->mapWithKeys(static function (Payment $item): array {
-                        return [Payment::$methods[$key] => $item->aggregate];
+                        return [Payment::$methods[$item->method] => $item->aggregate];
                     })->toArray()
         );
     }

--- a/app/Nova/Metrics/PaymentMethodBreakdown.php
+++ b/app/Nova/Metrics/PaymentMethodBreakdown.php
@@ -43,31 +43,7 @@ class PaymentMethodBreakdown extends Partition
                     ->orderBy('aggregate', 'desc')
                     ->get()
                     ->mapWithKeys(static function (Payment $item): array {
-                        $key = $item->method;
-                        switch ($item->method) {
-                            case 'cash':
-                                $key = 'Cash';
-
-                                break;
-                            case 'check':
-                                $key = 'Check';
-
-                                break;
-                            case 'swipe':
-                                $key = 'Swiped Card';
-
-                                break;
-                            case 'square':
-                                $key = 'Square (Online)';
-
-                                break;
-                            case 'squarecash':
-                                $key = 'Square Cash';
-
-                                break;
-                        }
-
-                        return [$key => $item->aggregate];
+                        return [Payment::$methods[$key] => $item->aggregate];
                     })->toArray()
         );
     }

--- a/app/Nova/Payment.php
+++ b/app/Nova/Payment.php
@@ -6,6 +6,7 @@ declare(strict_types=1);
 
 namespace App\Nova;
 
+use App\Payment as AppPayment;
 use Illuminate\Http\Request;
 use Laravel\Nova\Fields\BelongsTo;
 use Laravel\Nova\Fields\Currency;
@@ -58,7 +59,7 @@ class Payment extends Resource
                 ]),
 
             Select::make('Payment Method', 'method')
-                ->options(self::$methods)
+                ->options(AppPayment::$methods)
                 ->displayUsingLabels()
                 ->sortable(),
 

--- a/app/Nova/Payment.php
+++ b/app/Nova/Payment.php
@@ -48,14 +48,6 @@ class Payment extends Resource
      */
     public function fields(Request $request): array
     {
-        $payment_methods = [
-            'cash' => 'Cash',
-            'squarecash' => 'Square Cash',
-            'check' => 'Check',
-            'swipe' => 'Swiped Card',
-            'square' => 'Square Checkout',
-        ];
-
         return [
             ID::make()
                 ->sortable(),
@@ -66,7 +58,7 @@ class Payment extends Resource
                 ]),
 
             Select::make('Payment Method', 'method')
-                ->options($payment_methods)
+                ->options(self::$methods)
                 ->displayUsingLabels()
                 ->sortable(),
 

--- a/app/Payment.php
+++ b/app/Payment.php
@@ -34,6 +34,7 @@ class Payment extends Model
      * new methods added here.
      *
      * @var array<string,string>
+     *
      * @phan-suppress PhanReadOnlyPublicProperty
      */
     public static $methods = [

--- a/app/Payment.php
+++ b/app/Payment.php
@@ -67,7 +67,7 @@ class Payment extends Model
      */
     public function getMethodPresentationAttribute(): string
     {
-        return array_key_exists($this->method, $methods) ? $methods[$this->method] : '';
+        return array_key_exists($this->method, self::$methods) ? self::$methods[$this->method] : '';
     }
 
     /**

--- a/app/Payment.php
+++ b/app/Payment.php
@@ -34,6 +34,7 @@ class Payment extends Model
      * new methods added here.
      *
      * @var array<string,string>
+     * @phan-suppress PhanReadOnlyPublicProperty
      */
     public static $methods = [
         'cash' => 'Cash',

--- a/app/Payment.php
+++ b/app/Payment.php
@@ -30,6 +30,21 @@ class Payment extends Model
     protected $guarded = ['id'];
 
     /**
+     * All payment methods. Note that you probably want to also create a permission in the database for any
+     * new methods added here.
+     *
+     * @var array<string,string>
+     */
+    public static $methods = [
+        'cash' => 'Cash',
+        'squarecash' => 'Square Cash',
+        'check' => 'Check',
+        'swipe' => 'Swiped Card',
+        'square' => 'Square Checkout',
+        'waiver' => 'Waiver',
+    ];
+
+    /**
      * Get all of the owning payable models.
      */
     public function payable(): MorphTo
@@ -52,17 +67,7 @@ class Payment extends Model
      */
     public function getMethodPresentationAttribute(): string
     {
-        $valueMap = [
-            'cash' => 'Cash',
-            'squarecash' => 'Square Cash',
-            'check' => 'Check',
-            'swipe' => 'Swiped Card',
-            'square' => 'Square',
-        ];
-
-        $method = $this->method;
-
-        return array_key_exists($method, $valueMap) ? $valueMap[$this->method] : '';
+        return array_key_exists($this->method, $methods) ? $methods[$this->method] : '';
     }
 
     /**

--- a/database/migrations/2019_11_17_141409_add_waiver_payment_method_permission.php
+++ b/database/migrations/2019_11_17_141409_add_waiver_payment_method_permission.php
@@ -1,8 +1,6 @@
 <?php
 
 use Illuminate\Database\Migrations\Migration;
-use Illuminate\Database\Schema\Blueprint;
-use Illuminate\Support\Facades\Schema;
 
 class AddWaiverPaymentMethodPermission extends Migration
 {

--- a/database/migrations/2019_11_17_141409_add_waiver_payment_method_permission.php
+++ b/database/migrations/2019_11_17_141409_add_waiver_payment_method_permission.php
@@ -1,6 +1,8 @@
 <?php
 
 use Illuminate\Database\Migrations\Migration;
+use Spatie\Permission\Models\Permission;
+use Spatie\Permission\Models\Role;
 
 class AddWaiverPaymentMethodPermission extends Migration
 {

--- a/database/migrations/2019_11_17_141409_add_waiver_payment_method_permission.php
+++ b/database/migrations/2019_11_17_141409_add_waiver_payment_method_permission.php
@@ -1,0 +1,38 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddWaiverPaymentMethodPermission extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        // Reset cached roles and permissions
+        app()['cache']->forget('spatie.permission.cache');
+
+        $p_create_payments_waiver = Permission::firstOrCreate(['name' => 'create-payments-waiver']);
+
+        $r_admin = Role::firstOrCreate(['name' => 'admin']);
+        $r_admin->givePermissionTo($create_payments_waiver);
+        $r_officer = Role::firstOrCreate(['name' => 'officer']);
+        $r_officer->givePermissionTo($p_create_payments_waiver);
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        // Reset cached roles and permissions
+        app()['cache']->forget('spatie.permission.cache');
+        Permission::where('name', 'create-payments-waiver')->delete();
+    }
+}

--- a/database/migrations/2019_11_17_141409_add_waiver_payment_method_permission.php
+++ b/database/migrations/2019_11_17_141409_add_waiver_payment_method_permission.php
@@ -19,7 +19,7 @@ class AddWaiverPaymentMethodPermission extends Migration
         $p_create_payments_waiver = Permission::firstOrCreate(['name' => 'create-payments-waiver']);
 
         $r_admin = Role::firstOrCreate(['name' => 'admin']);
-        $r_admin->givePermissionTo($create_payments_waiver);
+        $r_admin->givePermissionTo($p_create_payments_waiver);
         $r_officer = Role::firstOrCreate(['name' => 'officer']);
         $r_officer->givePermissionTo($p_create_payments_waiver);
     }

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -111,6 +111,7 @@
         <exclude name="SlevomatCodingStandard.Functions.TrailingCommaInCall"/>
     </rule>
 
+    <rule ref="SlevomatCodingStandard.Namespaces.AlphabeticallySortedUses"/>
     <rule ref="SlevomatCodingStandard.Namespaces.DisallowGroupUse"/>
     <rule ref="SlevomatCodingStandard.Namespaces.MultipleUsesPerLine"/>
     <rule ref="SlevomatCodingStandard.Namespaces.NamespaceDeclaration"/>


### PR DESCRIPTION
I also took this opportunity to clean up the 6 maps where payment methods are defined and add a CodeSniffer check for alphabetically sorted `use` statements.

Closes #964.