### PR TITLE
Skip users who have never logged in in PushToJedi

### DIFF
--- a/app/Jobs/PushToJedi.php
+++ b/app/Jobs/PushToJedi.php
@@ -78,6 +78,12 @@ class PushToJedi implements ShouldQueue
             return;
         }
 
+        // Skip users who have never logged in as they will not have access to anything. This allows running on every
+        // user but saving some time.
+        if (! $this->user->has_logged_in) {
+            return;
+        }
+
         $lastAttendance = $this->user->attendance()->where('attendable_type', Team::class)
             ->orderBy('created_at', 'desc')->first();
 

--- a/app/Jobs/PushToJedi.php
+++ b/app/Jobs/PushToJedi.php
@@ -80,7 +80,7 @@ class PushToJedi implements ShouldQueue
 
         // Skip users who have never logged in as they will not have access to anything. This allows running on every
         // user but saving some time.
-        if (! $this->user->has_logged_in) {
+        if (! $this->user->has_ever_logged_in) {
             return;
         }
 

--- a/app/User.php
+++ b/app/User.php
@@ -28,6 +28,7 @@ use Spatie\Permission\Traits\HasRoles;
  *
  * @property bool $is_active whether the user is currently active
  * @property bool $is_service_account whether the user is a service account (vs human)
+ * @property bool $has_ever_logged_in whether the user has ever logged in with CAS
  * @property string $name the display name for this user
  */
 class User extends Authenticatable


### PR DESCRIPTION
They can't have access to anything so this will save some time when running the sync on all users.