### PR TITLE
Do not display the start time of an event on the RSVP confirmation view

### DIFF
--- a/resources/views/rsvp/confirmation.blade.php
+++ b/resources/views/rsvp/confirmation.blade.php
@@ -28,9 +28,6 @@
                 @isset($event['location'])
                     <b>Location: </b> {{ $event->location }}<br/>
                 @endisset
-                @isset($event['start_time'])
-                    <b>Date: </b> {{ date("l, F jS, Y \a\\t h:i A" ,strtotime($event->start_time)) }}<br/>
-                @endisset
                 @if($event['cost'] != 0)
                     <b>Cost: </b> ${{ $event->cost }}
                 @endif


### PR DESCRIPTION
This is a temporary fix for general interest, where we have two times for the event but one RSVP link.