### PR TITLE
Clean up duplicated code in Nova

### DIFF
--- a/app/Http/Requests/StoreUserRequest.php
+++ b/app/Http/Requests/StoreUserRequest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Http\Requests;
 
+use App\Models\User;
 use Illuminate\Foundation\Http\FormRequest;
 
 class StoreUserRequest extends FormRequest
@@ -81,11 +82,11 @@ class StoreUserRequest extends FormRequest
                 'max:6',
             ],
             'shirt_size' => [
-                'in:s,m,l,xl,xxl,xxxl',
+                'in:'.implode(',', array_keys(User::$shirt_sizes)),
                 'nullable',
             ],
             'polo_size' => [
-                'in:s,m,l,xl,xxl,xxxl',
+                'in:'.implode(',', array_keys(User::$shirt_sizes)),
                 'nullable',
             ],
             'accept_safety_agreement' => [

--- a/app/Http/Requests/UpdateUserRequest.php
+++ b/app/Http/Requests/UpdateUserRequest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Http\Requests;
 
+use App\Models\User;
 use Illuminate\Foundation\Http\FormRequest;
 
 class UpdateUserRequest extends FormRequest
@@ -62,11 +63,11 @@ class UpdateUserRequest extends FormRequest
                 'max:6',
             ],
             'shirt_size' => [
-                'in:s,m,l,xl,xxl,xxxl',
+                'in:'.implode(',', array_keys(User::$shirt_sizes)),
                 'nullable',
             ],
             'polo_size' => [
-                'in:s,m,l,xl,xxl,xxxl',
+                'in:'.implode(',', array_keys(User::$shirt_sizes)),
                 'nullable',
             ],
             'accept_safety_agreement' => [

--- a/app/Models/Team.php
+++ b/app/Models/Team.php
@@ -55,6 +55,7 @@ use Laravel\Nova\Actions\Actionable;
  * @property \Illuminate\Support\Carbon|null $deleted_at
  * @property bool $self_serviceable whether this team can be joined/left voluntarily
  * @property bool $visible whether this team is visible to non-admins
+ * @property bool $attendable
  * @property int $id the database identifier for this team
  * @property int|null $project_manager_id
  * @property string $name The name of the team
@@ -100,12 +101,15 @@ class Team extends Model
     ];
 
     /**
-     * The attributes that should be mutated to dates.
+     * The attributes that should be cast to native types.
      *
-     * @var array<string>
+     * @var array<string,string>
      */
     protected $casts = [
+        'attendable' => 'boolean',
         'attendance_secret_expiration' => 'datetime',
+        'self_serviceable' => 'boolean',
+        'visible' => 'boolean',
     ];
 
     /**

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -91,7 +91,7 @@ use Spatie\Permission\Traits\HasRoles;
  * @property Carbon|null $accept_safety_agreement
  * @property Carbon|null $access_override_until
  * @property Carbon|null $deleted_at
- * @property Carbon|null $resume_date
+ * @property ?\Carbon\Carbon $resume_date
  * @property int $gtid
  * @property int $id
  * @property int|null $access_override_by_id

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -239,6 +239,20 @@ class User extends Authenticatable
     ];
 
     /**
+     * List of valid shirt sizes and display names for them.
+     *
+     * @var array<string,string>
+     */
+    public static $shirt_sizes = [
+        's' => 'Small',
+        'm' => 'Medium',
+        'l' => 'Large',
+        'xl' => 'Extra-Large',
+        'xxl' => 'XXL',
+        'xxxl' => 'XXXL',
+    ];
+
+    /**
      *  Get the recruiting visits associated with this user.
      */
     public function recruitingVisits(): HasMany

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -242,6 +242,8 @@ class User extends Authenticatable
      * List of valid shirt sizes and display names for them.
      *
      * @var array<string,string>
+     *
+     * @phan-suppress PhanReadOnlyPublicProperty
      */
     public static $shirt_sizes = [
         's' => 'Small',

--- a/app/Nova/Attendance.php
+++ b/app/Nova/Attendance.php
@@ -18,7 +18,6 @@ use Laravel\Nova\Fields\DateTime;
 use Laravel\Nova\Fields\MorphTo;
 use Laravel\Nova\Fields\Text;
 use Laravel\Nova\Http\Requests\LensRequest;
-use Laravel\Nova\Panel;
 
 /**
  * A Nova resource for attendance.
@@ -120,23 +119,7 @@ class Attendance extends Resource
                 ->hideFromIndex()
                 ->sortable(),
 
-            new Panel('Metadata', $this->metaFields()),
-        ];
-    }
-
-    /**
-     * Timestamp fields.
-     *
-     * @return array<\Laravel\Nova\Fields\Field>
-     */
-    protected function metaFields(): array
-    {
-        return [
-            DateTime::make('Created', 'created_at')
-                ->onlyOnDetail(),
-
-            DateTime::make('Last Updated', 'updated_at')
-                ->onlyOnDetail(),
+            self::metadataPanel(),
         ];
     }
 

--- a/app/Nova/AttendanceExport.php
+++ b/app/Nova/AttendanceExport.php
@@ -9,7 +9,6 @@ use Illuminate\Http\Request;
 use Laravel\Nova\Fields\BelongsTo;
 use Laravel\Nova\Fields\DateTime;
 use Laravel\Nova\Fields\Text;
-use Laravel\Nova\Panel;
 
 class AttendanceExport extends Resource
 {
@@ -88,23 +87,7 @@ class AttendanceExport extends Resource
                 ->hideFromIndex()
                 ->nullable(),
 
-            new Panel('Metadata', $this->metaFields()),
-        ];
-    }
-
-    /**
-     * Timestamp fields.
-     *
-     * @return array<\Laravel\Nova\Fields\Field>
-     */
-    protected function metaFields(): array
-    {
-        return [
-            DateTime::make('Created', 'created_at')
-                ->exceptOnForms(),
-
-            DateTime::make('Last Updated', 'updated_at')
-                ->onlyOnDetail(),
+            self::metadataPanel(),
         ];
     }
 }

--- a/app/Nova/ClassStanding.php
+++ b/app/Nova/ClassStanding.php
@@ -6,9 +6,7 @@ namespace App\Nova;
 
 use Illuminate\Http\Request;
 use Laravel\Nova\Fields\BelongsToMany;
-use Laravel\Nova\Fields\DateTime;
 use Laravel\Nova\Fields\Text;
-use Laravel\Nova\Panel;
 
 class ClassStanding extends Resource
 {
@@ -52,16 +50,7 @@ class ClassStanding extends Resource
 
             BelongsToMany::make('Members', 'members', User::class),
 
-            new Panel(
-                'Metadata',
-                [
-                    DateTime::make('Created', 'created_at')
-                        ->onlyOnDetail(),
-
-                    DateTime::make('Last Updated', 'updated_at')
-                        ->onlyOnDetail(),
-                ]
-            ),
+            self::metadataPanel(),
         ];
     }
 }

--- a/app/Nova/DuesPackage.php
+++ b/app/Nova/DuesPackage.php
@@ -152,7 +152,7 @@ class DuesPackage extends Resource
                     return $request->user()->can('read-dues-transactions');
                 }),
 
-            new Panel('Metadata', $this->metaFields()),
+            self::metadataPanel(),
         ];
     }
 
@@ -169,22 +169,6 @@ class DuesPackage extends Resource
 
             Boolean::make('Eligible for Polo')
                 ->hideFromIndex(),
-        ];
-    }
-
-    /**
-     * Timestamp fields.
-     *
-     * @return array<\Laravel\Nova\Fields\Field>
-     */
-    protected function metaFields(): array
-    {
-        return [
-            DateTime::make('Created', 'created_at')
-                ->onlyOnDetail(),
-
-            DateTime::make('Last Updated', 'updated_at')
-                ->onlyOnDetail(),
         ];
     }
 }

--- a/app/Nova/DuesTransaction.php
+++ b/app/Nova/DuesTransaction.php
@@ -110,6 +110,7 @@ class DuesTransaction extends Resource
                         ->onlyOnDetail(),
                     Text::make('Size', function (): ?string {
                         $shirt_size = $this->user->shirt_size;
+
                         return null === $shirt_size ? null : AppModelsUser::$shirt_sizes[$shirt_size];
                     })->onlyOnDetail(),
                     DateTime::make('Timestamp', 'swag_shirt_provided')
@@ -127,6 +128,7 @@ class DuesTransaction extends Resource
                         ->onlyOnDetail(),
                     Text::make('Size', function (): ?string {
                         $polo_size = $this->user->polo_size;
+
                         return null === $polo_size ? null : AppModelsUser::$shirt_sizes[$polo_size];
                     })->onlyOnDetail(),
                     DateTime::make('Timestamp', 'swag_polo_provided')

--- a/app/Nova/DuesTransaction.php
+++ b/app/Nova/DuesTransaction.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Nova;
 
 use App\Models\DuesTransaction as AppModelsDuesTransaction;
+use App\Models\User as AppModelsUser;
 use Illuminate\Http\Request;
 use Laravel\Nova\Fields\BelongsTo;
 use Laravel\Nova\Fields\Currency;
@@ -108,16 +109,8 @@ class DuesTransaction extends Resource
                     Text::make('Status', 'swag_shirt_status')
                         ->onlyOnDetail(),
                     Text::make('Size', function (): ?string {
-                        $shirt_sizes = [
-                            's' => 'Small',
-                            'm' => 'Medium',
-                            'l' => 'Large',
-                            'xl' => 'Extra-Large',
-                            'xxl' => 'XXL',
-                            'xxxl' => 'XXXL',
-                        ];
-
-                        return null === $this->user->shirt_size ? null : $shirt_sizes[$this->user->shirt_size];
+                        $shirt_size = $this->user->shirt_size;
+                        return null === $shirt_size ? null : AppModelsUser::$shirt_sizes[$shirt_size];
                     })->onlyOnDetail(),
                     DateTime::make('Timestamp', 'swag_shirt_provided')
                         ->onlyOnDetail(),
@@ -133,16 +126,8 @@ class DuesTransaction extends Resource
                     Text::make('Status', 'swag_polo_status')
                         ->onlyOnDetail(),
                     Text::make('Size', function (): ?string {
-                        $shirt_sizes = [
-                            's' => 'Small',
-                            'm' => 'Medium',
-                            'l' => 'Large',
-                            'xl' => 'Extra-Large',
-                            'xxl' => 'XXL',
-                            'xxxl' => 'XXXL',
-                        ];
-
-                        return null === $this->user->polo_size ? null : $shirt_sizes[$this->user->polo_size];
+                        $polo_size = $this->user->polo_size;
+                        return null === $polo_size ? null : AppModelsUser::$shirt_sizes[$polo_size];
                     })->onlyOnDetail(),
                     DateTime::make('Timestamp', 'swag_polo_provided')
                         ->onlyOnDetail(),
@@ -155,34 +140,8 @@ class DuesTransaction extends Resource
             MorphMany::make('Payments', 'payment', Payment::class)
                 ->onlyOnDetail(),
 
-            new Panel('Metadata', $this->metaFields()),
+            self::metadataPanel(),
         ];
-    }
-
-    /**
-     * Timestamp fields.
-     *
-     * @return array<\Laravel\Nova\Fields\Field>
-     */
-    protected function metaFields(): array
-    {
-        return [
-            DateTime::make('Created', 'created_at')
-                ->onlyOnDetail(),
-
-            DateTime::make('Last Updated', 'updated_at')
-                ->onlyOnDetail(),
-        ];
-    }
-
-    /**
-     * Get the cards available for the request.
-     *
-     * @return array<\Laravel\Nova\Card>
-     */
-    public function cards(Request $request): array
-    {
-        return [];
     }
 
     /**
@@ -200,16 +159,6 @@ class DuesTransaction extends Resource
             new Filters\DuesTransactionPaymentStatus(),
             new Filters\DuesTransactionSwagStatus(),
         ];
-    }
-
-    /**
-     * Get the lenses available for the resource.
-     *
-     * @return array<\Laravel\Nova\Lenses\Lens>
-     */
-    public function lenses(Request $request): array
-    {
-        return [];
     }
 
     /**

--- a/app/Nova/Event.php
+++ b/app/Nova/Event.php
@@ -14,7 +14,6 @@ use Laravel\Nova\Fields\Currency;
 use Laravel\Nova\Fields\DateTime;
 use Laravel\Nova\Fields\HasMany;
 use Laravel\Nova\Fields\Text;
-use Laravel\Nova\Panel;
 
 /**
  * A Nova resource for events.
@@ -89,7 +88,7 @@ class Event extends Resource
                 return route('events.rsvp', ['event' => $this->id]);
             })->onlyOnDetail(),
 
-            new Panel('Metadata', $this->metaFields()),
+            self::metadataPanel(),
 
             HasMany::make('RSVPs')
                 ->canSee(static function (Request $request): bool {
@@ -105,22 +104,6 @@ class Event extends Resource
                 ->canSee(static function (Request $request): bool {
                     return $request->user()->can('create-attendance');
                 }),
-        ];
-    }
-
-    /**
-     * Timestamp fields.
-     *
-     * @return array<\Laravel\Nova\Fields\Field>
-     */
-    protected function metaFields(): array
-    {
-        return [
-            DateTime::make('Created', 'created_at')
-                ->onlyOnDetail(),
-
-            DateTime::make('Last Updated', 'updated_at')
-                ->onlyOnDetail(),
         ];
     }
 
@@ -143,35 +126,5 @@ class Event extends Resource
                     return $request->user()->can('read-attendance');
                 }),
         ];
-    }
-
-    /**
-     * Get the filters available for the resource.
-     *
-     * @return array<\Laravel\Nova\Filters\Filter>
-     */
-    public function filters(Request $request): array
-    {
-        return [];
-    }
-
-    /**
-     * Get the lenses available for the resource.
-     *
-     * @return array<\Laravel\Nova\Lenses\Lens>
-     */
-    public function lenses(Request $request): array
-    {
-        return [];
-    }
-
-    /**
-     * Get the actions available for the resource.
-     *
-     * @return array<\Laravel\Nova\Actions\Action>
-     */
-    public function actions(Request $request): array
-    {
-        return [];
     }
 }

--- a/app/Nova/Major.php
+++ b/app/Nova/Major.php
@@ -10,9 +10,7 @@ use App\Nova\Metrics\StudentsInMajor;
 use App\Nova\Metrics\TotalMajors;
 use Illuminate\Http\Request;
 use Laravel\Nova\Fields\BelongsToMany;
-use Laravel\Nova\Fields\DateTime;
 use Laravel\Nova\Fields\Text;
-use Laravel\Nova\Panel;
 
 class Major extends Resource
 {
@@ -73,16 +71,7 @@ class Major extends Resource
 
             BelongsToMany::make('Members', 'members', User::class),
 
-            new Panel(
-                'Metadata',
-                [
-                    DateTime::make('Created', 'created_at')
-                        ->onlyOnDetail(),
-
-                    DateTime::make('Last Updated', 'updated_at')
-                        ->onlyOnDetail(),
-                ]
-            ),
+            self::metadataPanel(),
         ];
     }
 

--- a/app/Nova/Metrics/ShirtSizeBreakdown.php
+++ b/app/Nova/Metrics/ShirtSizeBreakdown.php
@@ -100,16 +100,7 @@ class ShirtSizeBreakdown extends Partition
             ->orderBy('size')
             ->get()
             ->mapWithKeys(static function (object $item): array {
-                $shirt_sizes = [
-                    's' => 'Small',
-                    'm' => 'Medium',
-                    'l' => 'Large',
-                    'xl' => 'Extra-Large',
-                    'xxl' => 'XXL',
-                    'xxxl' => 'XXXL',
-                ];
-
-                return [null !== $item->size ? $shirt_sizes[$item->size] : 'Unknown' => $item->count];
+                return [null !== $item->size ? User::$shirt_sizes[$item->size] : 'Unknown' => $item->count];
             })->toArray()
         );
     }

--- a/app/Nova/NotificationTemplate.php
+++ b/app/Nova/NotificationTemplate.php
@@ -5,8 +5,6 @@ declare(strict_types=1);
 namespace App\Nova;
 
 use Illuminate\Http\Request;
-use Laravel\Nova\Fields\BelongsTo;
-use Laravel\Nova\Fields\DateTime;
 use Laravel\Nova\Fields\Markdown;
 use Laravel\Nova\Fields\Text;
 use Laravel\Nova\Panel;
@@ -72,7 +70,7 @@ class NotificationTemplate extends Resource
 
             new Panel('Email Content', $this->basicFields()),
 
-            new Panel('Metadata', $this->metaFields()),
+            self::metadataPanel(),
         ];
     }
 
@@ -99,68 +97,5 @@ class NotificationTemplate extends Resource
                 ->rules('required')
                 ->hideFromIndex(),
         ];
-    }
-
-    /**
-     * Timestamp and creator fields.
-     *
-     * @return array<\Laravel\Nova\Fields\Field>
-     */
-    protected function metaFields(): array
-    {
-        return [
-
-            BelongsTo::make('User', 'creator')
-                ->searchable()
-                ->rules('required')
-                ->hideFromIndex()
-                ->hideWhenUpdating(),
-
-            DateTime::make('Created At')
-                ->onlyOnDetail(),
-
-            DateTime::make('Last Updated', 'updated_at')
-                ->onlyOnDetail(),
-        ];
-    }
-
-    /**
-     * Get the cards available for the request.
-     *
-     * @return array<\Laravel\Nova\Card>
-     */
-    public function cards(Request $request): array
-    {
-        return [];
-    }
-
-    /**
-     * Get the filters available for the resource.
-     *
-     * @return array<\Laravel\Nova\Filters\Filter>
-     */
-    public function filters(Request $request): array
-    {
-        return [];
-    }
-
-    /**
-     * Get the lenses available for the resource.
-     *
-     * @return array<\Laravel\Nova\Lenses\Lens>
-     */
-    public function lenses(Request $request): array
-    {
-        return [];
-    }
-
-    /**
-     * Get the actions available for the resource.
-     *
-     * @return array<\Laravel\Nova\Actions\Action>
-     */
-    public function actions(Request $request): array
-    {
-        return [];
     }
 }

--- a/app/Nova/Payment.php
+++ b/app/Nova/Payment.php
@@ -8,7 +8,6 @@ use App\Models\Payment as AppModelsPayment;
 use Illuminate\Http\Request;
 use Laravel\Nova\Fields\BelongsTo;
 use Laravel\Nova\Fields\Currency;
-use Laravel\Nova\Fields\DateTime;
 use Laravel\Nova\Fields\ID;
 use Laravel\Nova\Fields\MorphTo;
 use Laravel\Nova\Fields\Select;
@@ -87,7 +86,7 @@ class Payment extends Resource
 
             new Panel('Square Metadata', $this->squareFields()),
 
-            new Panel('Timestamps', $this->metaFields()),
+            self::metadataPanel(),
         ];
     }
 
@@ -144,61 +143,5 @@ class Payment extends Resource
             Text::make('Receipt URL')
                 ->onlyOnDetail(),
         ];
-    }
-
-    /**
-     * Timestamp fields.
-     *
-     * @return array<\Laravel\Nova\Fields\Field>
-     */
-    protected function metaFields(): array
-    {
-        return [
-            DateTime::make('Created', 'created_at')
-                ->onlyOnDetail(),
-
-            DateTime::make('Last Updated', 'updated_at')
-                ->onlyOnDetail(),
-        ];
-    }
-
-    /**
-     * Get the cards available for the request.
-     *
-     * @return array<\Laravel\Nova\Card>
-     */
-    public function cards(Request $request): array
-    {
-        return [];
-    }
-
-    /**
-     * Get the filters available for the resource.
-     *
-     * @return array<\Laravel\Nova\Filters\Filter>
-     */
-    public function filters(Request $request): array
-    {
-        return [];
-    }
-
-    /**
-     * Get the lenses available for the resource.
-     *
-     * @return array<\Laravel\Nova\Actions\Action>
-     */
-    public function lenses(Request $request): array
-    {
-        return [];
-    }
-
-    /**
-     * Get the actions available for the resource.
-     *
-     * @return array<\Laravel\Nova\Actions\Action>
-     */
-    public function actions(Request $request): array
-    {
-        return [];
     }
 }

--- a/app/Nova/RecruitingVisit.php
+++ b/app/Nova/RecruitingVisit.php
@@ -8,7 +8,6 @@ use App\Models\RecruitingResponse;
 use App\Nova\Actions\SendRecruitingEmail;
 use Illuminate\Http\Request;
 use Laravel\Nova\Fields\BelongsTo;
-use Laravel\Nova\Fields\DateTime;
 use Laravel\Nova\Fields\Text;
 use Laravel\Nova\Panel;
 
@@ -106,7 +105,7 @@ class RecruitingVisit extends Resource
 
             new Panel('Tracking Information', $this->trackingFields()),
 
-            new Panel('Metadata', $this->metaFields()),
+            self::metadataPanel(),
         ];
     }
 
@@ -126,52 +125,6 @@ class RecruitingVisit extends Resource
                 ->nullable()
                 ->searchable(),
         ];
-    }
-
-    /**
-     * Timestamp fields.
-     *
-     * @return array<\Laravel\Nova\Fields\Field>
-     */
-    protected function metaFields(): array
-    {
-        return [
-            DateTime::make('Created', 'created_at')
-                ->onlyOnDetail(),
-
-            DateTime::make('Last Updated', 'updated_at')
-                ->onlyOnDetail(),
-        ];
-    }
-
-    /**
-     * Get the cards available for the request.
-     *
-     * @return array<\Laravel\Nova\Card>
-     */
-    public function cards(Request $request): array
-    {
-        return [];
-    }
-
-    /**
-     * Get the filters available for the resource.
-     *
-     * @return array<\Laravel\Nova\Filters\Filter>
-     */
-    public function filters(Request $request): array
-    {
-        return [];
-    }
-
-    /**
-     * Get the lenses available for the resource.
-     *
-     * @return array<\Laravel\Nova\Lenses\Lens>
-     */
-    public function lenses(Request $request): array
-    {
-        return [];
     }
 
     /**

--- a/app/Nova/Resource.php
+++ b/app/Nova/Resource.php
@@ -5,7 +5,9 @@ declare(strict_types=1);
 namespace App\Nova;
 
 use Illuminate\Database\Eloquent\Builder;
+use Laravel\Nova\Fields\DateTime;
 use Laravel\Nova\Http\Requests\NovaRequest;
+use Laravel\Nova\Panel;
 use Laravel\Nova\Resource as NovaResource;
 
 abstract class Resource extends NovaResource
@@ -18,5 +20,22 @@ abstract class Resource extends NovaResource
     public static function indexQuery(NovaRequest $request, $query): Builder
     {
         return $query;
+    }
+
+    /**
+     * Timestamp fields.
+     */
+    protected static function metadataPanel(): Panel
+    {
+        return new Panel(
+            'Metadata',
+            [
+                DateTime::make('Created', 'created_at')
+                    ->onlyOnDetail(),
+
+                DateTime::make('Last Updated', 'updated_at')
+                    ->onlyOnDetail(),
+            ]
+        );
     }
 }

--- a/app/Nova/Rsvp.php
+++ b/app/Nova/Rsvp.php
@@ -6,7 +6,6 @@ namespace App\Nova;
 
 use Illuminate\Http\Request;
 use Laravel\Nova\Fields\BelongsTo;
-use Laravel\Nova\Fields\DateTime;
 use Laravel\Nova\Fields\Text;
 use Laravel\Nova\Panel;
 
@@ -74,7 +73,7 @@ class Rsvp extends Resource
 
             new Panel('Detailed Information', $this->detailedFields()),
 
-            new Panel('Metadata', $this->metaFields()),
+            self::metadataPanel(),
         ];
     }
 
@@ -95,61 +94,5 @@ class Rsvp extends Resource
             Text::make('Token')
                 ->hideFromIndex(),
         ];
-    }
-
-    /**
-     * Timestamp fields.
-     *
-     * @return array<\Laravel\Nova\Fields\Field>
-     */
-    protected function metaFields(): array
-    {
-        return [
-            DateTime::make('Created', 'created_at')
-                ->onlyOnDetail(),
-
-            DateTime::make('Last Updated', 'updated_at')
-                ->onlyOnDetail(),
-        ];
-    }
-
-    /**
-     * Get the cards available for the request.
-     *
-     * @return array<\Laravel\Nova\Card>
-     */
-    public function cards(Request $request): array
-    {
-        return [];
-    }
-
-    /**
-     * Get the filters available for the resource.
-     *
-     * @return array<\Laravel\Nova\Filters\Filter>
-     */
-    public function filters(Request $request): array
-    {
-        return [];
-    }
-
-    /**
-     * Get the lenses available for the resource.
-     *
-     * @return array<\Laravel\Nova\Lenses\Lens>
-     */
-    public function lenses(Request $request): array
-    {
-        return [];
-    }
-
-    /**
-     * Get the actions available for the resource.
-     *
-     * @return array<\Laravel\Nova\Actions\Action>
-     */
-    public function actions(Request $request): array
-    {
-        return [];
     }
 }

--- a/app/Nova/Team.php
+++ b/app/Nova/Team.php
@@ -80,8 +80,6 @@ class Team extends Resource
 
             new Panel('Controls', $this->controlFields()),
 
-            new Panel('Metadata', $this->metaFields()),
-
             BelongsToMany::make('Members', 'members', User::class)
                 ->canSee(static function (Request $request): bool {
                     return $request->user()->can('read-teams-membership') && $request->user()->can('read-users');
@@ -105,6 +103,8 @@ class Team extends Resource
 
                     return $request->user()->can('create-attendance');
                 }),
+
+            self::metadataPanel(),
         ];
     }
 
@@ -207,22 +207,6 @@ class Team extends Resource
     }
 
     /**
-     * Timestamp fields.
-     *
-     * @return array<\Laravel\Nova\Fields\Field>
-     */
-    protected function metaFields(): array
-    {
-        return [
-            DateTime::make('Created', 'created_at')
-                ->onlyOnDetail(),
-
-            DateTime::make('Last Updated', 'updated_at')
-                ->onlyOnDetail(),
-        ];
-    }
-
-    /**
      * Get the cards available for the request.
      *
      * @return array<\Laravel\Nova\Card>
@@ -251,26 +235,6 @@ class Team extends Resource
                     return $request->user()->can('read-attendance');
                 }),
         ];
-    }
-
-    /**
-     * Get the filters available for the resource.
-     *
-     * @return array<\Laravel\Nova\Filters\Filter>
-     */
-    public function filters(Request $request): array
-    {
-        return [];
-    }
-
-    /**
-     * Get the lenses available for the resource.
-     *
-     * @return array<\Laravel\Nova\Lenses\Lens>
-     */
-    public function lenses(Request $request): array
-    {
-        return [];
     }
 
     /**

--- a/app/Nova/User.php
+++ b/app/Nova/User.php
@@ -27,7 +27,7 @@ use Laravel\Nova\Panel;
 /**
  * A Nova resource for users.
  *
- * @property string $resume_date When this user's resume was uploaded
+ * @property ?\Carbon\Carbon $resume_date
  * @property string $uid this user's username
  */
 class User extends Resource

--- a/app/Nova/User.php
+++ b/app/Nova/User.php
@@ -37,7 +37,7 @@ class User extends Resource
      *
      * @var string
      */
-    public static $model = \App\Models\User::class;
+    public static $model = AppModelsUser::class;
 
     /**
      * The single value that should be used to represent the resource when being displayed.
@@ -322,23 +322,14 @@ class User extends Resource
      */
     protected function swagFields(): array
     {
-        $shirt_sizes = [
-            's' => 'Small',
-            'm' => 'Medium',
-            'l' => 'Large',
-            'xl' => 'Extra-Large',
-            'xxl' => 'XXL',
-            'xxxl' => 'XXXL',
-        ];
-
         return [
             Select::make('T-Shirt Size', 'shirt_size')
-                ->options($shirt_sizes)
+                ->options(AppModelsUser::$shirt_sizes)
                 ->displayUsingLabels()
                 ->hideFromIndex(),
 
             Select::make('Polo Size')
-                ->options($shirt_sizes)
+                ->options(AppModelsUser::$shirt_sizes)
                 ->displayUsingLabels()
                 ->hideFromIndex(),
         ];
@@ -427,16 +418,6 @@ class User extends Resource
             new Filters\UserType(),
             new Filters\UserTeam(),
         ];
-    }
-
-    /**
-     * Get the lenses available for the resource.
-     *
-     * @return array<\Laravel\Nova\Lenses\Lens>
-     */
-    public function lenses(Request $request): array
-    {
-        return [];
     }
 
     /**


### PR DESCRIPTION
Summary of changes:
- Move all references to shirt sizes to the `User` model (fixes #1518)
- Create a shared method for generating the `created_at`/`updated_at` fields we put in most Nova resources
- Delete empty Nova methods
- Clean up some magic properties