### PR TITLE
Add Nova action to reset idempotency key and clean up other actions

### DIFF
--- a/app/Http/Controllers/SquareCheckoutController.php
+++ b/app/Http/Controllers/SquareCheckoutController.php
@@ -58,7 +58,7 @@ class SquareCheckoutController extends Controller
             $payment->amount = 0.00;
             $payment->method = 'square';
             $payment->recorded_by = $user->id;
-            $payment->unique_id = self::generateUniqueId();
+            $payment->unique_id = Payment::generateUniqueId();
             $payment->notes = 'Checkout flow started';
 
             $transaction->payment()->save($payment);
@@ -206,11 +206,6 @@ class SquareCheckoutController extends Controller
             case OrderState::OPEN:
                 return view('square.processing');
         }
-    }
-
-    private static function generateUniqueId(): string
-    {
-        return bin2hex(openssl_random_pseudo_bytes(32));
     }
 
     private static function calculateSurcharge(int $amount): int

--- a/app/Models/Payment.php
+++ b/app/Models/Payment.php
@@ -172,4 +172,9 @@ class Payment extends Model
         $this->entry_method = $transaction->entry_method;
         $this->save();
     }
+
+    public static function generateUniqueId(): string
+    {
+        return bin2hex(openssl_random_pseudo_bytes(32));
+    }
 }

--- a/app/Nova/Actions/AddPayment.php
+++ b/app/Nova/Actions/AddPayment.php
@@ -9,9 +9,6 @@ namespace App\Nova\Actions;
 use App\Models\DuesTransaction;
 use App\Models\Payment;
 use App\Notifications\Payment\ConfirmationNotification;
-use Illuminate\Bus\Queueable;
-use Illuminate\Queue\InteractsWithQueue;
-use Illuminate\Queue\SerializesModels;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Auth;
 use Laravel\Nova\Actions\Action;
@@ -21,10 +18,6 @@ use Laravel\Nova\Fields\Select;
 
 class AddPayment extends Action
 {
-    use InteractsWithQueue;
-    use Queueable;
-    use SerializesModels;
-
     /**
      * Perform the action on the given models.
      *

--- a/app/Nova/Actions/CreateDuesPackages.php
+++ b/app/Nova/Actions/CreateDuesPackages.php
@@ -54,7 +54,7 @@ class CreateDuesPackages extends Action
         $springAccessStart = Carbon::create($endingYear, 1, 1, 12, 0, 0, config('app.timezone'));
         $springAccessEnd = Carbon::create($endingYear, 9, 31, 12, 0, 0, config('app.timezone'));
 
-        if (0 === DuesPackage::where('name', $fallPackageName)->count()) {
+        if (DuesPackage::where('name', $fallPackageName)->doesntExist()) {
             $duesPackage = new DuesPackage();
             $duesPackage->name = $fallPackageName;
             $duesPackage->eligible_for_shirt = true;
@@ -72,7 +72,7 @@ class CreateDuesPackages extends Action
             $createdPackages++;
         }
 
-        if (0 === DuesPackage::where('name', $springPackageName)->count()) {
+        if (DuesPackage::where('name', $springPackageName)->doesntExist()) {
             $duesPackage = new DuesPackage();
             $duesPackage->name = $springPackageName;
             $duesPackage->eligible_for_shirt = false;
@@ -90,7 +90,7 @@ class CreateDuesPackages extends Action
             $createdPackages++;
         }
 
-        if (0 === DuesPackage::where('name', $studentFullYear)->count()) {
+        if (DuesPackage::where('name', $studentFullYear)->doesntExist()) {
             $duesPackage = new DuesPackage();
             $duesPackage->name = $studentFullYear;
             $duesPackage->eligible_for_shirt = true;
@@ -112,7 +112,7 @@ class CreateDuesPackages extends Action
             $createdPackages++;
         }
 
-        if (0 === DuesPackage::where('name', $nonStudentFullYear)->count() && true === $fields->non_student) {
+        if (DuesPackage::where('name', $nonStudentFullYear)->doesntExist() && true === $fields->non_student) {
             $duesPackage = new DuesPackage();
             $duesPackage->name = $nonStudentFullYear;
             $duesPackage->eligible_for_shirt = false;

--- a/app/Nova/Actions/DistributePolo.php
+++ b/app/Nova/Actions/DistributePolo.php
@@ -7,9 +7,6 @@ declare(strict_types=1);
 namespace App\Nova\Actions;
 
 use Carbon\Carbon;
-use Illuminate\Bus\Queueable;
-use Illuminate\Queue\InteractsWithQueue;
-use Illuminate\Queue\SerializesModels;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Str;
@@ -18,10 +15,6 @@ use Laravel\Nova\Fields\ActionFields;
 
 class DistributePolo extends Action
 {
-    use InteractsWithQueue;
-    use Queueable;
-    use SerializesModels;
-
     /**
      * Perform the action on the given models.
      *

--- a/app/Nova/Actions/DistributeShirt.php
+++ b/app/Nova/Actions/DistributeShirt.php
@@ -7,9 +7,6 @@ declare(strict_types=1);
 namespace App\Nova\Actions;
 
 use Carbon\Carbon;
-use Illuminate\Bus\Queueable;
-use Illuminate\Queue\InteractsWithQueue;
-use Illuminate\Queue\SerializesModels;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Str;
@@ -18,10 +15,6 @@ use Laravel\Nova\Fields\ActionFields;
 
 class DistributeShirt extends Action
 {
-    use InteractsWithQueue;
-    use Queueable;
-    use SerializesModels;
-
     /**
      * Perform the action on the given models.
      *

--- a/app/Nova/Actions/OverrideAccess.php
+++ b/app/Nova/Actions/OverrideAccess.php
@@ -5,9 +5,6 @@ declare(strict_types=1);
 namespace App\Nova\Actions;
 
 use App\Models\MembershipAgreementTemplate;
-use Illuminate\Bus\Queueable;
-use Illuminate\Queue\InteractsWithQueue;
-use Illuminate\Queue\SerializesModels;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Auth;
@@ -17,10 +14,6 @@ use Laravel\Nova\Fields\Date;
 
 class OverrideAccess extends Action
 {
-    use InteractsWithQueue;
-    use Queueable;
-    use SerializesModels;
-
     /**
      * Perform the action on the given models.
      *

--- a/app/Nova/Actions/RefreshFromGTED.php
+++ b/app/Nova/Actions/RefreshFromGTED.php
@@ -5,19 +5,12 @@ declare(strict_types=1);
 namespace App\Nova\Actions;
 
 use App\Jobs\CreateOrUpdateUserFromBuzzAPI;
-use Illuminate\Bus\Queueable;
-use Illuminate\Queue\InteractsWithQueue;
-use Illuminate\Queue\SerializesModels;
 use Illuminate\Support\Collection;
 use Laravel\Nova\Actions\Action;
 use Laravel\Nova\Fields\ActionFields;
 
 class RefreshFromGTED extends Action
 {
-    use InteractsWithQueue;
-    use Queueable;
-    use SerializesModels;
-
     /**
      * The displayable name of the action.
      *

--- a/app/Nova/Actions/ResetApiToken.php
+++ b/app/Nova/Actions/ResetApiToken.php
@@ -4,19 +4,12 @@ declare(strict_types=1);
 
 namespace App\Nova\Actions;
 
-use Illuminate\Bus\Queueable;
-use Illuminate\Queue\InteractsWithQueue;
-use Illuminate\Queue\SerializesModels;
 use Illuminate\Support\Collection;
 use Laravel\Nova\Actions\Action;
 use Laravel\Nova\Fields\ActionFields;
 
 class ResetApiToken extends Action
 {
-    use InteractsWithQueue;
-    use Queueable;
-    use SerializesModels;
-
     /**
      * The displayable name of the action.
      *

--- a/app/Nova/Actions/ResetIdempotencyKey.php
+++ b/app/Nova/Actions/ResetIdempotencyKey.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Nova\Actions;
+
+use App\Models\Payment;
+use Illuminate\Support\Collection;
+use Laravel\Nova\Actions\Action;
+use Laravel\Nova\Actions\DestructiveAction;
+use Laravel\Nova\Fields\ActionFields;
+
+class ResetIdempotencyKey extends DestructiveAction
+{
+    /**
+     * Indicates if this action is only available on the resource detail view.
+     *
+     * @var bool
+     */
+    public $onlyOnDetail = true;
+
+    /**
+     * Perform the action on the given models.
+     *
+     * @param \Illuminate\Support\Collection<\App\Models\Payment>  $models
+     *
+     * @return array<string,string>
+     */
+    public function handle(ActionFields $fields, Collection $models): array
+    {
+        if (count($models) > 1) {
+            return Action::danger('This action can only be run on one payment at a time.');
+        }
+
+        $payment = $models->first();
+        $payment->unique_id = Payment::generateUniqueId();
+        $payment->save();
+
+        return Action::message('The idempotency key was reset!');
+    }
+
+    /**
+     * Get the fields available on the action.
+     *
+     * @return array<\Laravel\Nova\Fields\Field>
+     */
+    public function fields(): array
+    {
+        return [];
+    }
+}

--- a/app/Nova/Actions/SendRecruitingEmail.php
+++ b/app/Nova/Actions/SendRecruitingEmail.php
@@ -6,9 +6,6 @@ namespace App\Nova\Actions;
 
 use App\Models\RecruitingVisit;
 use App\Notifications\GeneralInterestNotification;
-use Illuminate\Bus\Queueable;
-use Illuminate\Queue\InteractsWithQueue;
-use Illuminate\Queue\SerializesModels;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Notification;
 use Laravel\Nova\Actions\Action;
@@ -16,10 +13,6 @@ use Laravel\Nova\Fields\ActionFields;
 
 class SendRecruitingEmail extends Action
 {
-    use InteractsWithQueue;
-    use Queueable;
-    use SerializesModels;
-
     /**
      * Perform the action on the given models.
      *

--- a/app/Nova/Actions/SyncAccess.php
+++ b/app/Nova/Actions/SyncAccess.php
@@ -5,19 +5,12 @@ declare(strict_types=1);
 namespace App\Nova\Actions;
 
 use App\Jobs\PushToJedi;
-use Illuminate\Bus\Queueable;
-use Illuminate\Queue\InteractsWithQueue;
-use Illuminate\Queue\SerializesModels;
 use Illuminate\Support\Collection;
 use Laravel\Nova\Actions\Action;
 use Laravel\Nova\Fields\ActionFields;
 
 class SyncAccess extends Action
 {
-    use InteractsWithQueue;
-    use Queueable;
-    use SerializesModels;
-
     /**
      * Perform the action on the given models.
      *

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -7,7 +7,7 @@ parameters:
     - storage/*
     - vendor/*
   ignoreErrors:
-    - '#(?:Dynamic call to static method|Call to an undefined method) Illuminate\\Database\\Eloquent\\(?:Builder|Relations\\[a-zA-Z]+)?(?:<mixed>|<App\\Models\\[a-zA-Z,\\]+>|<Illuminate\\Database\\Eloquent\\Model>)?::(?:distinct|doesntHave|first|groupBy|has|havingRaw|join|leftJoin|orderBy|orderByRaw|orWhereNull|select|selectRaw|selectSub|where|whereBetween|whereDate|whereIn|whereNotNull|count|whereIn|whereBetween|sum|distinct|paid|active|accessActive|inactive|role|pending|pendingSwag|accessInactive|visible|whereNull|current|start|end|availableForPurchase|userCanPurchase|pluck|orderByDesc|withTrashed|exists|limit)\(\)\.#'
+    - '#(?:Dynamic call to static method|Call to an undefined method) Illuminate\\Database\\Eloquent\\(?:Builder|Relations\\[a-zA-Z]+)?(?:<mixed>|<App\\Models\\[a-zA-Z,\\]+>|<Illuminate\\Database\\Eloquent\\Model>)?::(?:distinct|doesntHave|first|groupBy|has|havingRaw|join|leftJoin|orderBy|orderByRaw|orWhereNull|select|selectRaw|selectSub|where|whereBetween|whereDate|whereIn|whereNotNull|count|whereIn|whereBetween|sum|distinct|paid|active|accessActive|inactive|role|pending|pendingSwag|accessInactive|visible|whereNull|current|start|end|availableForPurchase|userCanPurchase|pluck|orderByDesc|withTrashed|exists|limit|doesntExist)\(\)\.#'
     - '#Access to an undefined property Laravel\\Nova\\Fields\\ActionFields::\$[a-zA-Z_]+\.#'
     - '#Access to an undefined property Spatie\\Permission\\Contracts\\Permission::\$id\.#'
     - '#Access to an undefined property Spatie\\Permission\\Contracts\\Permission::\$name\.#'


### PR DESCRIPTION
Summary of changes:
- Clean up unneeded `use` statements
- Clean up some queries
- Move `SquareCheckoutController::generateUniqueId` to `Payment` model
- Add a new action for resetting the `unique_id` on a `Payment`

This allows a new Square Order to be created if the one previously attached to the payment was cancelled (I think orders can time out and then they move to this state? we'll see if anyone runs into it)

It's not strictly necessary but it's cleaner and safer than deleting payments.