### PR TITLE
Tweak payment instructions

### DIFF
--- a/resources/js/components/PaymentInstructions.vue
+++ b/resources/js/components/PaymentInstructions.vue
@@ -2,7 +2,6 @@
   <div>
     <h3>Payment Instructions</h3>
       <slot></slot>
-    <h3>Accepted Payment Methods</h3>
     <div class="row">
       <div class="col-12 col-lg-4">
         <div class="card">

--- a/resources/js/components/dues/DuesSequence.vue
+++ b/resources/js/components/dues/DuesSequence.vue
@@ -40,7 +40,7 @@
     <div v-show="currentStepName == 'dues-payment-instructions'">
       <payment-instructions>
         <p>
-          To complete your annual registration, please submit the SGA-mandated dues payments. RoboJackets dues are $100 for the year or $55 for the semester.
+          To complete your registration, please make a payment using one of the following methods.
         </p>
       </payment-instructions>
     </div>


### PR DESCRIPTION
This pull request closes #1579.

Before:
![Screenshot from 2021-01-30 12-12-08](https://user-images.githubusercontent.com/10482109/106363110-8ce08a00-62f4-11eb-9eda-21234c3c8978.png)

After:
![Screenshot from 2021-01-30 12-10-15](https://user-images.githubusercontent.com/10482109/106363118-91a53e00-62f4-11eb-8e1e-42773ad70a48.png)

I would like to show the pricing for the selected dues package but that seems complicated.