### PR TITLE
Improved validation and error handling for user edit forms

### DIFF
--- a/app/Http/Requests/UpdateUserRequest.php
+++ b/app/Http/Requests/UpdateUserRequest.php
@@ -34,6 +34,7 @@ class UpdateUserRequest extends FormRequest
                 'max:255',
                 'nullable',
                 'unique:users,personal_email,'.$this->user()->id,
+                'email:rfc,strict,dns,spoof',
             ],
             'first_name' => [
                 'max:127',
@@ -48,13 +49,18 @@ class UpdateUserRequest extends FormRequest
                 'max:127',
             ],
             'phone' => [
-                'max:15',
+                'digits_between:10,15',
             ],
             'emergency_contact_name' => [
+                'nullable',
                 'max:255',
+                'required_with:emergency_contact_phone',
             ],
             'emergency_contact_phone' => [
-                'max:15',
+                'nullable',
+                'digits_between:10,15',
+                'different:phone',
+                'required_with:emergency_contact_name',
             ],
             'join_semester' => [
                 'max:6',
@@ -90,7 +96,7 @@ class UpdateUserRequest extends FormRequest
             'clickup_email' => [
                 'string',
                 'nullable',
-                'email',
+                'email:rfc,strict,dns,spoof',
             ],
             'clickup_id' => [
                 'integer',
@@ -102,7 +108,7 @@ class UpdateUserRequest extends FormRequest
             'autodesk_email' => [
                 'string',
                 'nullable',
-                'email',
+                'email:rfc,strict,dns,spoof',
             ],
             'autodesk_invite_pending' => [
                 'boolean',

--- a/app/Http/Requests/UpdateUserRequest.php
+++ b/app/Http/Requests/UpdateUserRequest.php
@@ -52,15 +52,13 @@ class UpdateUserRequest extends FormRequest
                 'digits_between:10,15',
             ],
             'emergency_contact_name' => [
-                'nullable',
+                'required',
                 'max:255',
-                'required_with:emergency_contact_phone',
             ],
             'emergency_contact_phone' => [
-                'nullable',
+                'required',
                 'digits_between:10,15',
                 'different:phone',
-                'required_with:emergency_contact_name',
             ],
             'join_semester' => [
                 'max:6',

--- a/resources/js/components/UserEditForm.vue
+++ b/resources/js/components/UserEditForm.vue
@@ -315,6 +315,10 @@ export default {
           console.log('success');
         })
         .catch(response => {
+          if (response.response.status === 422) {
+            Swal.fire('Invalid Data', response.response.data.errors[Object.keys(response.response.data.errors)[0]][0], 'error');
+            return;
+          }
           this.hasError = true;
           this.feedback = '';
           console.log(response);

--- a/resources/js/components/UserEditForm.vue
+++ b/resources/js/components/UserEditForm.vue
@@ -314,14 +314,26 @@ export default {
 
           console.log('success');
         })
-        .catch(response => {
-          if (response.response.status === 422) {
-            Swal.fire('Invalid Data', response.response.data.errors[Object.keys(response.response.data.errors)[0]][0], 'error');
+        .catch(error => {
+          if (
+            error &&
+            error.response &&
+            error.response.status === 422 &&
+            error.response.data &&
+            error.response.data.errors &&
+            typeof error.response.data.errors === 'object' &&
+            error.response.data.errors !== null &&
+            Object.keys(error.response.data.errors).length > 0 &&
+            typeof error.response.data.errors[Object.keys(error.response.data.errors)[0]] === 'object' &&
+            error.response.data.errors[Object.keys(error.response.data.errors)[0]].length > 0
+          ) {
+            let errors = error.response.data.errors;
+            Swal.fire('Invalid Data', errors[Object.keys(errors)[0]][0], 'error');
             return;
           }
           this.hasError = true;
           this.feedback = '';
-          console.log(response);
+          console.log(error);
           Swal.fire(
             'Connection Error',
             'Unable to save data. Check your internet connection or try refreshing the page.',

--- a/resources/js/components/dues/DuesAdditionalInfo.vue
+++ b/resources/js/components/dues/DuesAdditionalInfo.vue
@@ -124,12 +124,24 @@ export default {
         .then(response => {
           this.$emit('next');
         })
-        .catch(response => {
-          if (response.response.status === 422) {
-            Swal.fire('Invalid Data', response.response.data.errors[Object.keys(response.response.data.errors)[0]][0], 'error');
+        .catch(error => {
+          if (
+            error &&
+            error.response &&
+            error.response.status === 422 &&
+            error.response.data &&
+            error.response.data.errors &&
+            typeof error.response.data.errors === 'object' &&
+            error.response.data.errors !== null &&
+            Object.keys(error.response.data.errors).length > 0 &&
+            typeof error.response.data.errors[Object.keys(error.response.data.errors)[0]] === 'object' &&
+            error.response.data.errors[Object.keys(error.response.data.errors)[0]].length > 0
+          ) {
+            let errors = error.response.data.errors;
+            Swal.fire('Invalid Data', errors[Object.keys(errors)[0]][0], 'error');
             return;
           }
-          console.log(response);
+          console.log(error);
           Swal.fire(
             'Connection Error',
             'Unable to save data. Check your internet connection or try refreshing the page.',

--- a/resources/js/components/dues/DuesAdditionalInfo.vue
+++ b/resources/js/components/dues/DuesAdditionalInfo.vue
@@ -81,7 +81,7 @@
               :class="{ 'is-invalid': $v.localUser.emergency_contact_phone.$error }"
               @input="$v.localUser.emergency_contact_phone.$touch()">
               <div class="invalid-feedback">
-                Must be a valid phone number with no punctuation
+                Must be a valid phone number with no punctuation, different from your phone number provided above
               </div>
           </div>
         </div>
@@ -125,6 +125,10 @@ export default {
           this.$emit('next');
         })
         .catch(response => {
+          if (response.response.status === 422) {
+            Swal.fire('Invalid Data', response.response.data.errors[Object.keys(response.response.data.errors)[0]][0], 'error');
+            return;
+          }
           console.log(response);
           Swal.fire(
             'Connection Error',


### PR DESCRIPTION
This pull request fixes #746.

Summary of changes:
- Additional validation for `personal_email`, `phone`, `emergency_contact_name`, `emergency_contact_phone`, `clickup_email`, `autodesk_email`
- Gracefully(ish) handle 422 errors on the profile page and on the additional info page in the dues flow