### PR TITLE
Only require emergency contact fields on frontend

### DIFF
--- a/app/Http/Requests/UpdateUserRequest.php
+++ b/app/Http/Requests/UpdateUserRequest.php
@@ -52,13 +52,15 @@ class UpdateUserRequest extends FormRequest
                 'digits_between:10,15',
             ],
             'emergency_contact_name' => [
-                'required',
+                'required_with:emergency_contact_phone',
                 'max:255',
+                'nullable',
             ],
             'emergency_contact_phone' => [
-                'required',
+                'required_with:emergency_contact_name',
                 'digits_between:10,15',
                 'different:phone',
+                'nullable',
             ],
             'join_semester' => [
                 'max:6',

--- a/resources/js/components/UserEditForm.vue
+++ b/resources/js/components/UserEditForm.vue
@@ -113,7 +113,8 @@
                 id="user-emergencyname"
                 placeholder="None on record"
                 :class="{ 'is-invalid': $v.user.emergency_contact_name.$error }"
-                @input="$v.user.emergency_contact_name.$touch()">
+                @input="$v.user.emergency_contact_name.$touch()"
+                required>
           </div>
         </div>
 
@@ -127,7 +128,8 @@
                 id="user-emergencyphone"
                 placeholder="None on record"
                 :class="{ 'is-invalid': $v.user.emergency_contact_phone.$error }"
-                @input="$v.user.emergency_contact_phone.$touch()">
+                @input="$v.user.emergency_contact_phone.$touch()"
+                required>
             <div class="invalid-feedback">
               Must be a valid phone number with no punctuation
             </div>
@@ -349,8 +351,8 @@ export default {
       preferred_first_name: { alpha },
       shirt_size: {},
       polo_size: {},
-      emergency_contact_name: {},
-      emergency_contact_phone: { maxLength: maxLength(15) },
+      emergency_contact_name: { required },
+      emergency_contact_phone: { required, maxLength: maxLength(15) },
     },
   },
 };

--- a/resources/js/components/dues/DuesAdditionalInfo.vue
+++ b/resources/js/components/dues/DuesAdditionalInfo.vue
@@ -66,7 +66,8 @@
               class="form-control"
               id="user-emergencycontactname"
               :class="{ 'is-invalid': $v.localUser.emergency_contact_name.$error }"
-              @input="$v.localUser.emergency_contact_name.$touch()">
+              @input="$v.localUser.emergency_contact_name.$touch()"
+              required>
           </div>
         </div>
         <div class="form-group row">
@@ -79,7 +80,8 @@
               id="user-emergencycontactphone"
               maxlength="15"
               :class="{ 'is-invalid': $v.localUser.emergency_contact_phone.$error }"
-              @input="$v.localUser.emergency_contact_phone.$touch()">
+              @input="$v.localUser.emergency_contact_phone.$touch()"
+              required>
               <div class="invalid-feedback">
                 Must be a valid phone number with no punctuation, different from your phone number provided above
               </div>
@@ -102,7 +104,7 @@
 </template>
 
 <script>
-import { alpha, email, minLength, maxLength } from 'vuelidate/lib/validators';
+import { alpha, email, minLength, maxLength, required } from 'vuelidate/lib/validators';
 import notGTEmail from '../../customValidators/notGTEmail';
 
 export default {
@@ -160,8 +162,8 @@ export default {
       personal_email: { email, notGTEmail },
       phone: { maxLength: maxLength(15) },
       preferred_first_name: { alpha },
-      emergency_contact_name: {},
-      emergency_contact_phone: { maxLength: maxLength(15) },
+      emergency_contact_name: { required },
+      emergency_contact_phone: { required, maxLength: maxLength(15) },
     },
   },
 };


### PR DESCRIPTION
This pull request fixes #1616.

Summary of changes:
- API no longer requires emergency contact fields unless one is already set
- Frontend requires both to be set on the user edit form and during dues flow