### PR TITLE
Improve handling of multiple active TAs

### DIFF
--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -29,7 +29,7 @@
             @endif
 
             @if (auth()->user() && auth()->user()->assignments()->count() > 0)
-            <li class="nav-item {{ $request->is('travel*') ? 'active' : '' }}">
+            <li class="nav-item {{ $request->is('travel*') || $request->is('pay/travel*') ? 'active' : '' }}">
               <a class="nav-link" href="{{ route('travel.index') }}">Travel<sub><small>&nbspbeta</small></sub></a>
             </li>
             @endif


### PR DESCRIPTION
- `DashboardController` uses same logic as `SquareCheckoutController` for selecting TAs that need payment (in particular, it will show ANY TA that needs payment not just the newest one)
- `SquareCheckoutController` picks oldest matching TA instead of newest
- Highlight Travel tab on `/pay/travel`

Fixes #1953 