### PR TITLE
Update .env.example to be more useful

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,9 +1,9 @@
-APP_NAME=DEV MyRoboJackets
+APP_NAME="DEV MyRoboJackets"
 APP_ENV=local
 APP_KEY=
 APP_DEBUG=true
 APP_LOG_LEVEL=debug
-APP_URL=http://localhost
+APP_URL=http://localhost:8000
 
 LOG_CHANNEL=stack
 
@@ -29,20 +29,21 @@ MAIL_FROM_NAME=MyRoboJackets
 MAILGUN_DOMAIN=
 MAILGUN_SECRET=
 
-CAS_HOSTNAME=cas.university.edu
-CAS_REAL_HOSTS=cas.university.edu
+CAS_HOSTNAME=sso.gatech.edu
+CAS_REAL_HOSTS=sso.gatech.edu
 CAS_SESSION_NAME=session
-CAS_LOGOUT_URL=
+CAS_LOGOUT_URL=https://sso.gatech.edu/cas/logout
 CAS_ENABLE_SAML=true
-CAS_DEBUG=
-CAS_VERBOSE_ERRORS=
-CAS_MASQUERADE=
-CAS_MASQUERADE_gtGTID=
-CAS_MASQUERADE_email_primary=
-CAS_MASQUERADE_givenName=
-CAS_MASQUERADE_sn=
+CAS_DEBUG=true
+CAS_VERBOSE_ERRORS=true
+CAS_MASQUERADE=gburdell3
+CAS_MASQUERADE_gtGTID=903000000
+CAS_MASQUERADE_email_primary=gburdell3@gatech.edu
+CAS_MASQUERADE_givenName=George
+CAS_MASQUERADE_sn=Burdell
 CAS_MASQUERADE_gtPersonEntitlement=/gt/departmental/studentlife/studentgroups/RoboJackets/BattleBots,/gt/departmental/studentlife/studentgroups/RoboJackets/Officers,/gt/departmental/studentlife/studentgroups/RoboJackets/Core
 CAS_MASQUERADE_gtAccountEntitlement=/gt/central/services/iam/two-factor/duo-user
+CAS_MASQUERADE_eduPersonPrimaryAffiliation=student
 CAS_MASQUERADE_authn_method=duo-two-factor
 
 SQUARE_TOKEN=""
@@ -51,8 +52,8 @@ SQUARE_LOCATION_ID=""
 FAILED_JOB_EMAIL_ADDRESS=
 FAILED_JOB_SLACK_WEBHOOK_URL=
 
-JEDI_HOST=
-JEDI_TOKEN=
+JEDI_HOST=null
+JEDI_TOKEN=null
 
 GITHUB_CLIENT_ID=
 GITHUB_CLIENT_SECRET=
@@ -74,3 +75,11 @@ MIX_SENTRY_AUTH_TOKEN="${SENTRY_AUTH_TOKEN}"
 MIX_SENTRY_ORG_NAME="${SENTRY_ORG_NAME}"
 MIX_SENTRY_PROJECT_ID="${SENTRY_PROJECT_ID}"
 SENTRY_TRACES_SAMPLE_RATE=1
+
+BUZZAPI_HOST=my.robojackets.org
+BUZZAPI_APP_ID=demo
+BUZZAPI_APP_PASSWORD=demo
+BUZZAPI_TIMEOUT=1
+BUZZAPI_CONNECT_TIMEOUT=1
+
+SCOUT_DRIVER=collection


### PR DESCRIPTION
- Fix whitespace issue with `APP_NAME`
- Set default `php artisan serve` port in `APP_URL`
- Update CAS fields
- Explicitly set JEDI fields to null so it doesn't try to push there
- Set Scout driver to `collection` so it doesn't talk to Algolia/Meilisearch
- Point BuzzAPI to mock endpoint on prod server