### PR TITLE
Move #treasury bot to midnight

### DIFF
--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -34,7 +34,7 @@ class Kernel extends ConsoleKernel
         $schedule->job(new WeeklyAttendanceEmail())->weekly()->sundays()->at('1:00');
         $schedule->job(new WeeklyAttendanceSlack())->weekly()->sundays()->at('11:00');
         $schedule->job(new SendExpiringPersonalAccessTokenNotifications())->weekly()->mondays()->at('08:00');
-        $schedule->job(new DailyDuesSummary())->daily()->at('11:00');
+        $schedule->job(new DailyDuesSummary())->daily()->at('00:00');
         $schedule->job(new NoAttendanceJediPush())->daily()->at('10:00');
     }
 


### PR DESCRIPTION
There's odd "race conditions" when people pay dues before 11AM (the previously scheduled time) where the numbers appear to not add up from day-to-day.