### PR TITLE
Require read-users-gtid for attendance export

### DIFF
--- a/app/Nova/Attendance.php
+++ b/app/Nova/Attendance.php
@@ -185,9 +185,9 @@ class Attendance extends Resource
     {
         return [
             (new ExportAttendance())->canSee(static function (Request $request): bool {
-                return $request->user()->can('read-attendance');
+                return $request->user()->can('read-attendance') && $request->user()->can('read-users-gtid');
             })->canRun(static function (Request $request): bool {
-                return $request->user()->can('read-attendance');
+                return $request->user()->can('read-attendance') && $request->user()->can('read-users-gtid');
             })->confirmButtonText('Export Attendance'),
         ];
     }


### PR DESCRIPTION
This reverts commit 16dfe489e8987f0cc7bb2e9d81e8c284ad1bd39b. This fixes #1758.