### PR TITLE
Add user impersonation

### DIFF
--- a/app/Http/Controllers/AuthController.php
+++ b/app/Http/Controllers/AuthController.php
@@ -4,7 +4,10 @@ declare(strict_types=1);
 
 namespace App\Http\Controllers;
 
+use App\Models\User;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+use Laravel\Nova\Contracts\ImpersonatesUsers;
 
 class AuthController extends Controller
 {
@@ -25,5 +28,14 @@ class AuthController extends Controller
     {
         $request->session()->regenerate();
         cas()->logout(config('app.url'));
+    }
+
+    public function stopImpersonating(Request $request, ImpersonatesUsers $impersonator)
+    {
+        if ($impersonator->impersonating($request)) {
+            $impersonator->stopImpersonating($request, Auth::guard(), User::class);
+        }
+
+        return redirect(route('home'));
     }
 }

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -23,6 +23,7 @@ use Illuminate\Notifications\Notifiable;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Cache;
 use Laravel\Nova\Actions\Actionable;
+use Laravel\Nova\Auth\Impersonatable;
 use Laravel\Nova\Notifications\Notification;
 use Laravel\Passport\HasApiTokens;
 use Laravel\Scout\Searchable;
@@ -190,6 +191,7 @@ class User extends Authenticatable
     use HasApiTokens;
     use FirstNameSynonyms;
     use Searchable;
+    use Impersonatable;
 
     private const MAJOR_ENTITLEMENT_PREFIX = '/gt/gtad/gt_resources/stu_majorgroups/';
     private const MAJOR_ENTITLEMENT_PREFIX_LENGTH = 38;
@@ -887,6 +889,14 @@ class User extends Authenticatable
 
             return [] === $result ? null : $result[0][0];
         });
+    }
+
+    /**
+     * Determine if the user can impersonate another user.
+     */
+    public function canImpersonate(): bool
+    {
+        return $this->can('impersonate-users');
     }
 
     /**

--- a/app/Providers/NovaServiceProvider.php
+++ b/app/Providers/NovaServiceProvider.php
@@ -16,6 +16,8 @@ use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Gate;
 use Laravel\Nova\Events\ServingNova;
+use Laravel\Nova\Menu\Menu;
+use Laravel\Nova\Menu\MenuItem;
 use Laravel\Nova\Nova;
 use Laravel\Nova\NovaApplicationServiceProvider;
 use Vyuldashev\NovaPermission\NovaPermissionTool;
@@ -47,6 +49,31 @@ class NovaServiceProvider extends NovaApplicationServiceProvider
             if (app()->bound('sentry')) {
                 app('sentry')->captureException($exception);
             }
+        });
+
+        Nova::userMenu(static function (Request $request, Menu $menu): Menu {
+            $menu->append(
+                MenuItem::externalLink(
+                    'Member Dashboard',
+                    route('home')
+                )
+            );
+
+            $menu->append(
+                MenuItem::make(
+                    'Profile',
+                    '/resources/users/'.$request->user()->getKey()
+                )
+            );
+
+            $menu->append(
+                MenuItem::externalLink(
+                    'Logout',
+                    route('logout')
+                )
+            );
+
+            return $menu;
         });
     }
 

--- a/app/Providers/NovaServiceProvider.php
+++ b/app/Providers/NovaServiceProvider.php
@@ -28,6 +28,7 @@ class NovaServiceProvider extends NovaApplicationServiceProvider
     public function boot(): void
     {
         parent::boot();
+
         Nova::serving(static function (ServingNova $event): void {
             Nova::script('apiary-custom', asset('js/nova.js'));
         });

--- a/database/migrations/2022_06_04_104801_add_impersonate_users_permission.php
+++ b/database/migrations/2022_06_04_104801_add_impersonate_users_permission.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Spatie\Permission\Models\Permission;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        app()['cache']->forget('spatie.permission.cache');
+
+        Permission::firstOrCreate(['name' => 'impersonate-users']);
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        app()['cache']->forget('spatie.permission.cache');
+        Permission::where('name', 'impersonate-users')->delete();
+    }
+};

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -5,8 +5,14 @@
   </head>
 
   <body>
+    @inject('request', 'Illuminate\Http\Request')
+    @if (app(\Laravel\Nova\Contracts\ImpersonatesUsers::class)->impersonating($request))
+    <div style="text-align: center; height: 3em; padding: 0.7em; background-color: #eed202;">
+        <strong>You are impersonating another user.</strong>
+        <span>This functionality should only be used when troubleshooting an issue.</span>
+    </div>
+    @endif
     <nav class="navbar navbar-expand-lg navbar-dark bg-dark">
-      @inject('request', 'Illuminate\Http\Request')
       <div class="container">
         <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarNavDropdown" aria-controls="navbarNavDropdown" aria-expanded="false" aria-label="Toggle navigation">
           <span class="navbar-toggler-icon"></span>

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -10,6 +10,7 @@
     <div style="text-align: center; height: 3em; padding: 0.7em; background-color: #eed202;">
         <strong>You are impersonating another user.</strong>
         <span>This functionality should only be used when troubleshooting an issue.</span>
+        <a href="{{ route('stopImpersonating') }}">Click here to stop impersonating.</a>
     </div>
     @endif
     <nav class="navbar navbar-expand-lg navbar-dark bg-dark">

--- a/routes/web.php
+++ b/routes/web.php
@@ -81,6 +81,8 @@ Route::middleware('auth.cas.force')->group(static function (): void {
 
     Route::view('oauth2/client', 'oauth2clientcreated')->name('oauth2.client.created');
     Route::view('oauth2/pat', 'personalaccesstokencreated')->name('oauth2.pat.created');
+
+    Route::get('stop-impersonating', [AuthController::class, 'stopImpersonating'])->name('stopImpersonating');
 });
 
 Route::get('/events/{event}/rsvp', [RsvpController::class, 'storeUser'])

--- a/tests/Feature/PermissionsAndRolesTest.php
+++ b/tests/Feature/PermissionsAndRolesTest.php
@@ -26,7 +26,9 @@ class PermissionsAndRolesTest extends TestCase
     public function testAdminRoleHasAllPermissions(): void
     {
         $permissions = Role::where('name', 'admin')->first()->permissions;
-        $allPermissions = Permission::where('name', '!=', 'refund-payments')->get();
+        $allPermissions = Permission::where('name', '!=', 'refund-payments')
+            ->where('name', '!=', 'impersonate-users')
+            ->get();
         $this->assertCount(0, $permissions->diff($allPermissions));
         $this->assertCount(0, $allPermissions->diff($permissions));
     }


### PR DESCRIPTION
Closes #2073
Closes #2540 

This does not include any specific indication that you are impersonating another user, but given that (a) it is difficult to trigger accidentally and (b) the current user's name is on (almost) every page in the navbar, I don't know if that is strictly necessary.