### PR TITLE
Switch remaining emails to plain text

### DIFF
--- a/app/Mail/DuesPaymentReminder.php
+++ b/app/Mail/DuesPaymentReminder.php
@@ -20,8 +20,6 @@ class DuesPaymentReminder extends Mailable implements ShouldQueue
 
     /**
      * Create a new message instance.
-     *
-     * @return void
      */
     public function __construct(DuesTransaction $transaction)
     {
@@ -30,8 +28,6 @@ class DuesPaymentReminder extends Mailable implements ShouldQueue
 
     /**
      * Build the message.
-     *
-     * @return $this
      */
     public function build(): self
     {

--- a/app/Mail/MembershipAgreementSigned.php
+++ b/app/Mail/MembershipAgreementSigned.php
@@ -18,10 +18,8 @@ class MembershipAgreementSigned extends Mailable implements ShouldQueue
 
     /**
      * The signature that was just signed.
-     *
-     * @var \App\Models\Signature
      */
-    public $signature;
+    public Signature $signature;
 
     /**
      * Create a new message instance.
@@ -33,17 +31,17 @@ class MembershipAgreementSigned extends Mailable implements ShouldQueue
 
     /**
      * Build the message.
-     *
-     * @return $this
      */
-    public function build()
+    public function build(): self
     {
         return $this
             ->from('noreply@my.robojackets.org', 'RoboJackets')
+            ->to($this->signature->user->gt_email, $this->signature->user->name)
+            ->cc(config('services.membership_agreement_archive_email'))
             ->withSymfonyMessage(static function (Email $message): void {
                 $message->replyTo('RoboJackets <hello@robojackets.org>');
-            })->subject('[RoboJackets] Membership Agreement Signed')
-            ->markdown(
+            })->subject('Membership agreement signed')
+            ->text(
                 'mail.agreement.signed',
                 [
                     'agreement_text' => $this->signature->membershipAgreementTemplate->renderForUser(

--- a/app/Models/Signature.php
+++ b/app/Models/Signature.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Models;
 
 use Carbon\Carbon;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
@@ -60,6 +61,8 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
  */
 class Signature extends Model
 {
+    use HasFactory;
+
     /**
      * The attributes that are mass assignable.
      *

--- a/app/Notifications/ExpiringPersonalAccessTokenNotification.php
+++ b/app/Notifications/ExpiringPersonalAccessTokenNotification.php
@@ -7,10 +7,11 @@ namespace App\Notifications;
 use App\Mail\ExpiringPersonalAccessToken;
 use App\Models\User;
 use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Notifications\Notification;
 use Laravel\Passport\Token;
 
-class ExpiringPersonalAccessTokenNotification extends Notification
+class ExpiringPersonalAccessTokenNotification extends Notification implements ShouldQueue
 {
     use Queueable;
 
@@ -41,15 +42,18 @@ class ExpiringPersonalAccessTokenNotification extends Notification
      */
     public function toMail(User $notifiable): ExpiringPersonalAccessToken
     {
-        return (new ExpiringPersonalAccessToken($this->token))
-            ->to($notifiable->gt_email);
+        return new ExpiringPersonalAccessToken($this->token);
     }
 
     /**
-     * Get the array representation of the notification.
+     * Determine which queues should be used for each notification channel.
+     *
+     * @return array<string,string>
      */
-    public function toArray(User $notifiable): array
+    public function viaQueues(): array
     {
-        return [];
+        return [
+            'mail' => 'email',
+        ];
     }
 }

--- a/app/Notifications/MembershipAgreementSigned.php
+++ b/app/Notifications/MembershipAgreementSigned.php
@@ -17,10 +17,8 @@ class MembershipAgreementSigned extends Notification implements ShouldQueue
 
     /**
      * The signature that was just signed.
-     *
-     * @var \App\Models\Signature
      */
-    private $signature;
+    private Signature $signature;
 
     /**
      * Create a new notification instance.
@@ -48,18 +46,18 @@ class MembershipAgreementSigned extends Notification implements ShouldQueue
         // Force the relation to load, because it doesn't in the mail view for some reason.
         $this->signature->load('uploadedBy');
 
-        return (new Mailable($this->signature))
-            ->to($notifiable->gt_email)
-            ->cc(config('services.membership_agreement_archive_email'));
+        return new Mailable($this->signature);
     }
 
     /**
-     * Get the array representation of the notification.
+     * Determine which queues should be used for each notification channel.
      *
      * @return array<string,string>
      */
-    public function toArray(User $notifiable): array
+    public function viaQueues(): array
     {
-        return [];
+        return [
+            'mail' => 'email',
+        ];
     }
 }

--- a/database/factories/SignatureFactory.php
+++ b/database/factories/SignatureFactory.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Database\Factories;
+
+use App\Models\MembershipAgreementTemplate;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * A factory for signatures.
+ *
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\Signature>
+ */
+class SignatureFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, int|bool>
+     */
+    public function definition()
+    {
+        return [
+            'membership_agreement_template_id' => MembershipAgreementTemplate::all()->random()->id,
+            'user_id' => User::all()->random()->id,
+            'electronic' => false,
+        ];
+    }
+}

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -55,7 +55,6 @@ parameters:
     - '#Method App\\Models\\[a-zA-Z]+::getMorphClassStatic\(\) should return string but returns int\|string\|false\.#'
     - '#Method App\\Models\\[a-zA-Z]+::toSearchableArray\(\) should return array<string, int\|string> but returns array\.#'
     - '#Method App\\Notifiables\\[a-zA-Z]+::[a-zA-Z]+\(\) should return string\|null but returns mixed\.#'
-    - '#Method App\\Notifications\\ExpiringPersonalAccessTokenNotification::toArray\(\) return type has no value type specified in iterable type array\.#'
     - '#Method App\\Nova\\[a-zA-Z0-9]+::__invoke\(\) return type has no value type specified in iterable type array\.#'
     - '#Method App\\Nova\\[a-zA-Z0-9]+::fields\(\) return type has no value type specified in iterable type array\.#'
     - '#Method App\\Nova\\Actions\\CreateRemoteAttendanceLink::handle\(\) should return array<string, array<string, string>> but returns array<string, array<string, mixed>>\.#'

--- a/resources/views/mail/agreement/signed.blade.php
+++ b/resources/views/mail/agreement/signed.blade.php
@@ -1,11 +1,9 @@
-@component('mail::message')
-
-# Membership Agreement Signed
+Hi {{ $signature->user->preferred_first_name }},
 
 @if($signature->electronic)
 We received your electronically signed membership agreement at {{ $signature->cas_ticket_redeemed_timestamp }} from IP address {{ $signature->ip_address }}.
 @else
-Your signed membership agreement was uploaded to {{ config('app.name') }} at {{ $signature->updated_at }} by {{ $signature->uploadedBy->first_name }} {{ $signature->uploadedBy->last_name }}.
+Your signed membership agreement was uploaded to {{ config('app.name') }} at {{ $signature->updated_at }} by {{ $signature->uploadedBy->name }}.
 @endif
 
 The full text of the agreement is included below for your reference.
@@ -16,6 +14,4 @@ The full text of the agreement is included below for your reference.
 
 ---
 
-If you have any questions, please contact us at [hello@robojackets.org](mailto:hello@robojackets.org).
-
-@endcomponent
+If you have any questions, just reply to this email.

--- a/resources/views/mail/oauth2/pat_expiration.blade.php
+++ b/resources/views/mail/oauth2/pat_expiration.blade.php
@@ -1,13 +1,11 @@
-@component('mail::message')
-    @if($already_expired)
-        Your MyRoboJackets personal access token called "{{ $token->name }}" expired on {{ $token->expires_at }} and is no longer valid.
-    @else
-        Your MyRoboJackets personal access token called "{{ $token->name }}" will expire on {{ $token->expires_at }} and will not work after that time.
-    @endif
+Hi {{ $token->user->preferred_first_name }},
 
-Personal access token expiration dates cannot be extended. If you're still using this token, you must create a new personal access token to continue accessing the MyRoboJackets API.  You can create a new personal access token by accessing your user page in the MyRoboJackets admin interface and running the "Create Personal Access Token" action.
+@if($already_expired)
+Your {{ config('app.name') }} personal access token called "{{ $token->name }}" expired on {{ $token->expires_at }} and is no longer valid.
+@else
+Your {{ config('app.name') }} personal access token called "{{ $token->name }}" will expire on {{ $token->expires_at }} and will not work after that time.
+@endif
 
-Feel free to reach out to [#it-helpdesk](https://robojackets.slack.com/app_redirect?channel=it-helpdesk) in Slack for assistance creating a new personal access token.
+Token expiration dates cannot be extended. If you're still using this token, you must create a new token to continue accessing the {{ config('app.name') }} API.  You can create a new token by accessing your user page in the {{ config('app.name') }} admin interface and running the "Create Personal Access Token" action.
 
--RoboJackets IT
-@endcomponent
+If you need any assistance, please ask in #it-helpdesk in Slack.

--- a/tests/Unit/ExpiringPersonalAccessTokenEmailTest.php
+++ b/tests/Unit/ExpiringPersonalAccessTokenEmailTest.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit;
+
+use App\Mail\ExpiringPersonalAccessToken;
+use App\Models\User;
+use Illuminate\Support\Facades\Config;
+use Laravel\Passport\ClientRepository;
+use Tests\TestCase;
+
+class ExpiringPersonalAccessTokenEmailTest extends TestCase
+{
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $clientRepository = new ClientRepository();
+
+        $client = $clientRepository->createPersonalAccessClient(
+            null,
+            'test',
+            'http://localhost'
+        );
+
+        Config::set('passport.personal_access_client.id', $client->id);
+        Config::set('passport.personal_access_client.secret', $client->plain_secret);
+    }
+
+    public function testGenerateEmailForAlreadyExpiredToken(): void
+    {
+        $user = User::factory()->create();
+
+        $token = $user->createToken('email test token')->token;
+        $token->expires_at = now()->subHours(1);
+        $token->save();
+
+        $mailable = new ExpiringPersonalAccessToken($token);
+
+        $mailable->assertSeeInText($user->preferred_first_name);
+        $mailable->assertSeeInText('expired on');
+        $mailable->assertSeeInText($token->name);
+    }
+
+    public function testGenerateEmailForTokenExpiringSoon(): void
+    {
+        $user = User::factory()->create();
+
+        $token = $user->createToken('email test token')->token;
+        $token->expires_at = now()->addHours(1);
+        $token->save();
+
+        $mailable = new ExpiringPersonalAccessToken($token);
+
+        $mailable->assertSeeInText($user->preferred_first_name);
+        $mailable->assertSeeInText('will expire on');
+        $mailable->assertSeeInText($token->name);
+    }
+}

--- a/tests/Unit/MembershipAgreementSignedEmailTest.php
+++ b/tests/Unit/MembershipAgreementSignedEmailTest.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit;
+
+use App\Mail\MembershipAgreementSigned;
+use App\Models\MembershipAgreementTemplate;
+use App\Models\Signature;
+use App\Models\User;
+use Tests\TestCase;
+
+class MembershipAgreementSignedEmailTest extends TestCase
+{
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        MembershipAgreementTemplate::factory()->create();
+
+        User::factory()->create();
+    }
+
+    public function testGenerateEmailForPaperSignature(): void
+    {
+        $signature = Signature::factory()->create();
+        $signature->uploaded_by = User::factory()->create()->id;
+        $signature->save();
+
+        $mailable = new MembershipAgreementSigned($signature);
+
+        $mailable->assertSeeInText($signature->user->preferred_first_name);
+        $mailable->assertSeeInText('was uploaded');
+    }
+
+    public function testGenerateEmailForElectronicSignature(): void
+    {
+        $signature = Signature::factory()->create();
+        $signature->electronic = true;
+        $signature->save();
+
+        $mailable = new MembershipAgreementSigned($signature);
+
+        $mailable->assertSeeInText($signature->user->preferred_first_name);
+        $mailable->assertSeeInText('electronically signed');
+    }
+}


### PR DESCRIPTION
The membership agreement email will be disabled as part of #2516, but I am updating it here in case the timing on that does not work out or we need to disable it or whatever.