### PR TITLE
Tweak welcome language on home page

### DIFF
--- a/app/Http/Controllers/DashboardController.php
+++ b/app/Http/Controllers/DashboardController.php
@@ -158,7 +158,6 @@ class DashboardController extends Controller
             $travelAuthorityRequestUrl = $travelAssignmentWithNoTravelAuthorityRequest->travel_authority_request_url;
         }
 
-        $isEligibleForSelfServiceOverride = $user->self_service_override_eligibility->eligible;
         $teamAttendanceExists = $user->attendance()->whereAttendableType('team')->exists();
 
         return view(
@@ -184,7 +183,6 @@ class DashboardController extends Controller
                 'needTravelAuthorityRequest' => $needTravelAuthorityRequest,
                 'travelAuthorityRequestUrl' => $travelAuthorityRequestUrl,
                 'travelName' => $travelName,
-                'isEligibleForSelfServiceOverride' => $isEligibleForSelfServiceOverride,
                 'teamAttendanceExists' => $teamAttendanceExists,
             ]
         );

--- a/resources/js/components/dues/SelfServiceAccessOverride.vue
+++ b/resources/js/components/dues/SelfServiceAccessOverride.vue
@@ -7,7 +7,7 @@
           New Member Access
         </h4>
         <p class="card-text">
-          Welcome to RoboJackets! As a new member, you can request to temporarily use RoboJackets services without
+          As a new member, you can request to temporarily use RoboJackets services without
           paying dues until {{ overrideUntil }}.
         </p>
         <button class="btn btn-link p-0" @click="requestOverride()"

--- a/resources/views/welcome.blade.php
+++ b/resources/views/welcome.blade.php
@@ -15,7 +15,7 @@
             <div class="card">
                 <div class="card-body">
                     <h4 class="card-title">
-                        Welcome {{ $signedAnyAgreement ? "back" : "" }}, {{ $preferredName }}!
+                        Welcome{{ $signedAnyAgreement ? " back" : "" }}, {{ $preferredName }}!
                     </h4>
                     <p class="card-text">
                         @if($isNew)

--- a/resources/views/welcome.blade.php
+++ b/resources/views/welcome.blade.php
@@ -42,7 +42,7 @@
                                 Start Here
                             </h4>
                             <p class="card-text">
-                                Welcome to RoboJackets! Please review and sign the RoboJackets membership agreement. This document describes our expectations for your behavior in our facility, when traveling, and when representing RoboJackets.
+                                Please review and sign the RoboJackets membership agreement. It describes our expectations for your behavior in our facility, when traveling, and when representing RoboJackets.
                             </p>
                         @else
                             <h4 class="card-title">

--- a/resources/views/welcome.blade.php
+++ b/resources/views/welcome.blade.php
@@ -15,7 +15,7 @@
             <div class="card">
                 <div class="card-body">
                     <h4 class="card-title">
-                        Welcome back, {{ $preferredName }}!
+                        Welcome {{ $signedAnyAgreement ? "back" : "" }}, {{ $preferredName }}!
                     </h4>
                     <p class="card-text">
                         @if($isNew)
@@ -42,7 +42,7 @@
                                 Start Here
                             </h4>
                             <p class="card-text">
-                                Please review and sign the RoboJackets membership agreement. This document describes our expectations for your behavior in our facility, when traveling, and when representing RoboJackets.
+                                Welcome to RoboJackets! Please review and sign the RoboJackets membership agreement. This document describes our expectations for your behavior in our facility, when traveling, and when representing RoboJackets.
                             </p>
                         @else
                             <h4 class="card-title">


### PR DESCRIPTION
Adds logic for when to show "Welcome, George!" vs. "Welcome back, George!" ("Welcome back" will appear if the user has ever signed a membership agreement.)

Moves the "Welcome to RoboJackets" language from the New Member Access (self-service override) card to the Start Here (membership agreement) card.

Removes self-service override calculation from the dashboard template since it's unused.