### PR TITLE
Update Square order state handling

### DIFF
--- a/app/Jobs/FulfillSquareOrder.php
+++ b/app/Jobs/FulfillSquareOrder.php
@@ -27,11 +27,17 @@ class FulfillSquareOrder implements ShouldQueue, ShouldBeUnique
     use SerializesModels;
 
     /**
+     * The number of attempts for this job.
+     *
+     * @var int
+     */
+    public $tries = 1;
+
+    /**
      * Create a new job instance.
      */
     public function __construct(private string $order_id)
     {
-        $this->tries = 1;
         $this->queue = 'square';
     }
 

--- a/app/Jobs/FulfillSquareOrder.php
+++ b/app/Jobs/FulfillSquareOrder.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Jobs;
+
+use App\Models\Payment;
+use Exception;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldBeUnique;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use Square\Models\Order;
+use Square\Models\OrderFulfillment;
+use Square\Models\OrderFulfillmentState;
+use Square\Models\UpdateOrderRequest;
+use Square\SquareClient;
+
+class FulfillSquareOrder implements ShouldQueue, ShouldBeUnique
+{
+    use Dispatchable;
+    use InteractsWithQueue;
+    use Queueable;
+    use SerializesModels;
+
+    /**
+     * Create a new job instance.
+     */
+    public function __construct(private string $order_id)
+    {
+    }
+
+    /**
+     * Execute the job.
+     */
+    public function handle(): void
+    {
+        $square = new SquareClient([
+            'accessToken' => config('square.access_token'),
+            'environment' => config('square.environment'),
+        ]);
+
+        $ordersApi = $square->getOrdersApi();
+
+        $retrieveOrderResponse = $ordersApi->retrieveOrder($this->order_id);
+
+        if (! $retrieveOrderResponse->isSuccess()) {
+            throw new Exception(
+                'Error retrieving order: '.json_encode($retrieveOrderResponse->getErrors())
+            );
+        }
+
+        $retrievedOrder = $retrieveOrderResponse->getResult()->getOrder();
+
+        $updateFulfillment = new OrderFulfillment();
+        $updateFulfillment->setUid($retrievedOrder->getFulfillments()[0]->getUid());
+        $updateFulfillment->setState(OrderFulfillmentState::COMPLETED);
+
+        $updateOrder = new Order(config('square.location_id'));
+        $updateOrder->setFulfillments([$updateFulfillment]);
+        $updateOrder->setVersion($retrievedOrder->getVersion());
+
+        $updateOrderRequest = new UpdateOrderRequest();
+        $updateOrderRequest->setOrder($updateOrder);
+        $updateOrderRequest->setIdempotencyKey(Payment::generateUniqueId());
+
+        $ordersApi->updateOrder($this->order_id, $updateOrderRequest);
+    }
+
+    /**
+     * The unique ID of the job.
+     */
+    public function uniqueId(): string
+    {
+        return strval($this->order_id);
+    }
+}

--- a/app/Jobs/FulfillSquareOrder.php
+++ b/app/Jobs/FulfillSquareOrder.php
@@ -31,6 +31,8 @@ class FulfillSquareOrder implements ShouldQueue, ShouldBeUnique
      */
     public function __construct(private string $order_id)
     {
+        $this->tries = 1;
+        $this->queue = 'square';
     }
 
     /**

--- a/app/Jobs/ProcessSquareWebhook.php
+++ b/app/Jobs/ProcessSquareWebhook.php
@@ -113,5 +113,7 @@ class ProcessSquareWebhook extends ProcessWebhookJob
         }
 
         event(new PaymentSuccess($payment));
+
+        FulfillSquareOrder::dispatch($details['order_id']);
     }
 }

--- a/app/Jobs/PushToJedi.php
+++ b/app/Jobs/PushToJedi.php
@@ -66,7 +66,6 @@ class PushToJedi implements ShouldQueue, ShouldBeUnique
         $this->model_class = $model_class;
         $this->model_id = $model_id;
         $this->model_event = $model_event;
-        $this->tries = 1;
         $this->queue = 'jedi';
     }
 

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -83,9 +83,9 @@
     @include('layouts/footer')
   </body>
   <script src="{{ mix('/js/app.js') }}"></script>
-  @if (Session::has('sweet_alert.alert'))
+  @if (Session::has('alert.config'))
     <script>
-        Swal.fire({!! Session::pull('sweet_alert.alert') !!});
+        Swal.fire({!! Session::pull('alert.config') !!});
     </script>
   @endif
 </html>


### PR DESCRIPTION
Fixes #2691 

- When redirecting back from Square, Apiary will now check for tenders rather than order state
- Order state will be updated asynchronously when the `payment.created` webhook is received from Square
- Fixed SweetAlert being completely broken