### PR TITLE
Remove build-time patch of subfission/cas

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -74,7 +74,6 @@ RUN --mount=type=secret,id=composer_auth,dst=/app/auth.json,uid=33,gid=33,requir
     composer install --no-interaction --no-progress --no-dev --optimize-autoloader --classmap-authoritative --no-cache && \
     php artisan nova:publish && \
     php artisan horizon:publish && \
-    sed -i '/HTTPS_ONLY_COOKIES/c\true,' /app/vendor/subfission/cas/src/Subfission/Cas/CasManager.php && \
     sed -i '/"\$1\\n\$2"/c\\' /app/vendor/mrclay/minify/lib/Minify/HTML.php;
 
 # This target is the default, but skipped during pull request builds and in our recommended local build invocation


### PR DESCRIPTION
This shouldn't be necessary since `env(...)` still returns real environment variables (just not from `.env` files), and that's how we configure the containers.