### PR TITLE
Redirect /nova/login to /login/cas

### DIFF
--- a/routes/web.php
+++ b/routes/web.php
@@ -94,6 +94,7 @@ Route::middleware('auth.cas.force')->group(static function (): void {
 
     Route::redirect('admin', '/nova');
 
+    Route::redirect('nova/login', '/login/cas');
     Route::get('login/cas', [AuthController::class, 'forceCasAuth'])
         ->name('login.cas');
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -93,8 +93,8 @@ Route::middleware('auth.cas.force')->group(static function (): void {
     Route::get('travel', [TravelAssignmentController::class, 'index'])->name('travel.index');
 
     Route::redirect('admin', '/nova');
+    Route::redirect('nova/login', '/nova');
 
-    Route::redirect('nova/login', '/login/cas');
     Route::get('login/cas', [AuthController::class, 'forceCasAuth'])
         ->name('login.cas');
 


### PR DESCRIPTION
Nova redirects to that route intermittently, which is a 404 right now. This is probably not the _correct_ solution, but it will cover that case.