### PR TITLE
Expose managers for users

### DIFF
--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -127,7 +127,7 @@ class UserController extends Controller
                 ], 403);
             }
 
-            return response()->json(['status' => 'success', 'user' => new UserResource($user)]);
+            return response()->json(['status' => 'success', 'user' => new UserResource($user, true)]);
         }
 
         return response()->json(['status' => 'error', 'message' => 'User not found.'], 404);

--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -12,6 +12,7 @@ use App\Http\Requests\UpdateUserRequest;
 use App\Http\Resources\User as UserResource;
 use App\Models\User;
 use App\Traits\AuthorizeInclude;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Log;
@@ -39,6 +40,23 @@ class UserController extends Controller
         $users = User::with($this->authorizeInclude(User::class, $include))->get();
 
         return response()->json(['status' => 'success', 'users' => UserResource::collection($users)]);
+    }
+
+    public function indexManagers(Request $request): JsonResponse
+    {
+        return response()
+            ->json(
+                [
+                    'status' => 'success',
+                    'users' => UserResource::collection(
+                        User::whereHas('manages')
+                            ->orWhereHas('roles', static function (Builder $query): void {
+                                $query->whereIn('name', ['project-manager', 'officer']);
+                            })
+                            ->get()
+                    ),
+                ]
+            );
     }
 
     /**

--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -24,7 +24,7 @@ class UserController extends Controller
 
     public function __construct()
     {
-        $this->middleware('permission:read-users', ['only' => ['index', 'search']]);
+        $this->middleware('permission:read-users', ['only' => ['index', 'indexManagers', 'search']]);
         $this->middleware('permission:create-users', ['only' => ['store']]);
         $this->middleware('permission:read-users|read-users-own', ['only' => ['show']]);
         $this->middleware('permission:update-users|update-users-own', ['only' => ['update', 'applySelfOverride']]);

--- a/app/Http/Resources/User.php
+++ b/app/Http/Resources/User.php
@@ -30,6 +30,7 @@ class User extends JsonResource
             'uid' => $this->uid,
             'gtid' => $this->when(Auth::user()->can('read-users-gtid'), $this->gtid),
             'gt_email' => $this->gt_email,
+            'email_suppression_reason' => $this->email_suppression_reason,
             'first_name' => $this->first_name,
             'middle_name' => $this->middle_name,
             'last_name' => $this->last_name,

--- a/app/Http/Resources/User.php
+++ b/app/Http/Resources/User.php
@@ -16,6 +16,11 @@ use Illuminate\Support\Facades\Auth;
 
 class User extends JsonResource
 {
+    public function __construct(\App\Models\User $resource, private readonly bool $withManager = false)
+    {
+        parent::__construct($resource);
+    }
+
     /**
      * Transform the resource into an array.
      *
@@ -69,7 +74,7 @@ class User extends JsonResource
                 'has_ordered_polo' => $this->has_ordered_polo,
             ]),
             'manager' => $this->when(
-                Auth::user()->can('read-users'),
+                Auth::user()->can('read-users') && $this->withManager,
                 fn (): ?self => $this->manager === null ? null : new self($this->manager)
             ),
             'created_at' => $this->created_at,

--- a/app/Http/Resources/User.php
+++ b/app/Http/Resources/User.php
@@ -68,7 +68,7 @@ class User extends JsonResource
             $this->mergeWhen($this->requestingSelf($request) || Auth::user()->can('read-dues-transactions'), [
                 'has_ordered_polo' => $this->has_ordered_polo,
             ]),
-            'manager' => $this->manager,
+            'manager' => $this->when(Auth::user()->can('read-users'), fn (): ?User => $this->manager),
             'created_at' => $this->created_at,
             'updated_at' => $this->updated_at,
             'deleted_at' => $this->deleted_at,

--- a/app/Http/Resources/User.php
+++ b/app/Http/Resources/User.php
@@ -67,6 +67,7 @@ class User extends JsonResource
             $this->mergeWhen($this->requestingSelf($request) || Auth::user()->can('read-dues-transactions'), [
                 'has_ordered_polo' => $this->has_ordered_polo,
             ]),
+            'manager' => $this->manager,
             'created_at' => $this->created_at,
             'updated_at' => $this->updated_at,
             'deleted_at' => $this->deleted_at,
@@ -81,7 +82,8 @@ class User extends JsonResource
             $this->mergeWhen(
                 $this->resource->relationLoaded('permissions') && $this->resource->relationLoaded('roles'),
                 [
-                    'allPermissions' => $this->getAllPermissions()->pluck('name'),
+                    'allPermissions' => $this->resource->relationLoaded('permissions') &&
+                    $this->resource->relationLoaded('roles') ? $this->getAllPermissions()->pluck('name') : [],
                 ]
             ),
         ];

--- a/app/Http/Resources/User.php
+++ b/app/Http/Resources/User.php
@@ -68,7 +68,7 @@ class User extends JsonResource
             $this->mergeWhen($this->requestingSelf($request) || Auth::user()->can('read-dues-transactions'), [
                 'has_ordered_polo' => $this->has_ordered_polo,
             ]),
-            'manager' => $this->when(Auth::user()->can('read-users'), fn (): ?User => $this->manager),
+            'manager' => $this->when(Auth::user()->can('read-users'), fn (): ?self => new self($this->manager)),
             'created_at' => $this->created_at,
             'updated_at' => $this->updated_at,
             'deleted_at' => $this->deleted_at,

--- a/app/Http/Resources/User.php
+++ b/app/Http/Resources/User.php
@@ -68,7 +68,10 @@ class User extends JsonResource
             $this->mergeWhen($this->requestingSelf($request) || Auth::user()->can('read-dues-transactions'), [
                 'has_ordered_polo' => $this->has_ordered_polo,
             ]),
-            'manager' => $this->when(Auth::user()->can('read-users'), fn (): ?self => new self($this->manager)),
+            'manager' => $this->when(
+                Auth::user()->can('read-users'),
+                fn (): ?self => $this->manager === null ? null : new self($this->manager)
+            ),
             'created_at' => $this->created_at,
             'updated_at' => $this->updated_at,
             'deleted_at' => $this->deleted_at,

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -864,7 +864,14 @@ class User extends Authenticatable
      */
     protected function makeAllSearchableUsing(Builder $query): Builder
     {
-        return $query->withCount('attendance')->withCount('signatures');
+        return $query
+            ->withCount('attendance')
+            ->withCount('signatures')
+            ->with('classStanding')
+            ->with('majors')
+            ->with('teams')
+            ->with('permissions')
+            ->with('roles');
     }
 
     /**

--- a/app/Nova/Event.php
+++ b/app/Nova/Event.php
@@ -68,7 +68,7 @@ class Event extends Resource
                 ->sortable()
                 ->rules('required', 'max:255'),
 
-            (new BelongsTo('Organizer', 'organizer', User::class))
+            BelongsTo::make('Organizer', 'organizer', User::class)
                 ->searchable()
                 ->rules('required')
                 ->help('The organizer of the event'),

--- a/app/Nova/User.php
+++ b/app/Nova/User.php
@@ -418,7 +418,8 @@ class User extends Resource
 
             Text::make('Create Reason')
                 ->hideFromIndex()
-                ->required(),
+                ->required()
+                ->rules('required'),
 
             Text::make('gtDirGUID', 'gtDirGUID')
                 ->hideFromIndex(),

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -69,7 +69,7 @@ class AppServiceProvider extends ServiceProvider
         Model::shouldBeStrict();
 
         // Lazy-loading needs to be allowed for console commands due to https://github.com/laravel/scout/issues/462
-        if ($this->app->isProduction() && !$this->app->runningInConsole()) {
+        if ($this->app->isProduction() && ! $this->app->runningInConsole()) {
             Model::handleLazyLoadingViolationUsing(static function (Model $model, string $relation): void {
                 \Sentry\captureMessage('Attemped to lazy-load '.$relation.' on '.$model::class);
             });

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -69,7 +69,11 @@ class AppServiceProvider extends ServiceProvider
         Model::shouldBeStrict();
 
         // Lazy-loading needs to be allowed for console commands due to https://github.com/laravel/scout/issues/462
-        if ($this->app->isProduction() && ! $this->app->runningInConsole()) {
+        if ($this->app->runningInConsole()) {
+            Model::preventLazyLoading(false);
+        }
+
+        if ($this->app->isProduction()) {
             Model::handleLazyLoadingViolationUsing(static function (Model $model, string $relation): void {
                 \Sentry\captureMessage('Attemped to lazy-load '.$relation.' on '.$model::class);
             });

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -68,7 +68,8 @@ class AppServiceProvider extends ServiceProvider
 
         Model::shouldBeStrict();
 
-        if ($this->app->isProduction()) {
+        // Lazy-loading needs to be allowed for console commands due to https://github.com/laravel/scout/issues/462
+        if ($this->app->isProduction() && !$this->app->runningInConsole()) {
             Model::handleLazyLoadingViolationUsing(static function (Model $model, string $relation): void {
                 \Sentry\captureMessage('Attemped to lazy-load '.$relation.' on '.$model::class);
             });

--- a/config/features.php
+++ b/config/features.php
@@ -7,4 +7,5 @@ return [
     'card-present-payments' => env('FEATURE_ENABLE_CARD_PRESENT_PAYMENTS', false),
     'docusign-membership-agreement' => env('FEATURE_DOCUSIGN_MEMBERSHIP_AGREEMENT', true),
     'demo-mode' => env('DEMO_MODE_USER', null),
+    'whitepages' => env('FEATURE_ENABLE_WHITEPAGES', true),
 ];

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -130,6 +130,7 @@ parameters:
     - '#Parameter \#1 \$resolveCallback of method Laravel\\Nova\\Fields\\Field::resolveUsing\(\) expects callable\(mixed, mixed, string\|null\): mixed, Closure\(bool\): ''Electronic''\|''Paper'' given\.#'
     - '#Parameter \#1 \$resolveCallback of method Laravel\\Nova\\Fields\\Field::resolveUsing\(\) expects callable\(mixed, mixed, string\|null\): mixed, Closure\(Carbon\\Carbon\): Carbon\\Carbon\|null given\.#'
     - '#Parameter \#1 \$resolveCallback of method Laravel\\Nova\\Fields\\Field::resolveUsing\(\) expects callable\(mixed, mixed, string\|null\): mixed, Closure\(string\): string given\.#'
+    - '#Parameter \#1 \$resource of class App\\Http\\Resources\\User constructor expects App\\Models\\User, mixed given\.#'
     - '#Parameter \#1 \$resource of static method App\\Nova\\Metrics\\MembersForOneFiscalYear::query\(\) expects string, mixed given\.#'
     - '#Parameter \#1 \$resource of static method App\\Nova\\Metrics\\TotalCollections::query\(\) expects string, mixed given\.#'
     - '#Parameter \#1 \$resourceId of class App\\Nova\\Actions\\DistributeMerchandise constructor expects string\|null, mixed given\.#'

--- a/routes/api.php
+++ b/routes/api.php
@@ -38,6 +38,7 @@ Route::prefix('v1/')->name('api.v1.')->middleware(['auth:api'])->group(
         // Users
         // The search endpoint MUST be registered before the apiResource, otherwise it will not take precedence
         Route::get('users/search', [UserController::class, 'search']);
+        Route::get('users/managers', [UserController::class, 'indexManagers']);
         Route::apiResource('users', UserController::class);
         Route::post('users/{id}/resume', [ResumeController::class, 'store']);
         Route::get('user', [UserController::class, 'showSelf']);


### PR DESCRIPTION
- Fix #3075 because it was bothering me
- Add `GET /api/v1/users/managers` with a list of project managers of teams and users with a `project-manager` or `officer` role
- Add `manager` attribute to users computed based on attendance