### PR TITLE
Improve performance of manager index and user attribute

### DIFF
--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -9,6 +9,7 @@ namespace App\Http\Controllers;
 use App\Http\Requests\SelfServiceAccessOverrideRequest;
 use App\Http\Requests\StoreUserRequest;
 use App\Http\Requests\UpdateUserRequest;
+use App\Http\Resources\Manager;
 use App\Http\Resources\User as UserResource;
 use App\Models\User;
 use App\Traits\AuthorizeInclude;
@@ -48,7 +49,7 @@ class UserController extends Controller
             ->json(
                 [
                     'status' => 'success',
-                    'users' => UserResource::collection(
+                    'users' => Manager::collection(
                         User::whereHas('manages')
                             ->orWhereHas('roles', static function (Builder $query): void {
                                 $query->whereIn('name', ['project-manager', 'officer']);

--- a/app/Http/Resources/Manager.php
+++ b/app/Http/Resources/Manager.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Resources;
+
+use Illuminate\Http\Resources\Json\JsonResource;
+
+class Manager extends JsonResource
+{
+    /**
+     * Transform the resource into an array.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return array<string, int|string>
+     */
+    public function toArray($request): array
+    {
+        return [
+            'id' => $this->id,
+            'full_name' => $this->full_name,
+        ];
+    }
+}

--- a/app/Http/Resources/User.php
+++ b/app/Http/Resources/User.php
@@ -74,7 +74,7 @@ class User extends JsonResource
             ]),
             'manager' => $this->when(
                 Auth::user()->can('read-users') && $this->withManager,
-                fn (): ?self => $this->manager === null ? null : new self($this->manager)
+                fn (): ?Manager => $this->manager === null ? null : new Manager($this->manager)
             ),
             'created_at' => $this->created_at,
             'updated_at' => $this->updated_at,


### PR DESCRIPTION
Fixes #3423

Calculating `is_active` and some other attributes for each manager is expensive and unnecessary. This changes the `/api/v1/users/managers` endpoint and the `managers` attribute on users to only return the `id` and `full_name` attributes. This may change in the future.