### PR TITLE
Fix flaky test in PaymentTest feature test suite

### DIFF
--- a/tests/Feature/PaymentTest.php
+++ b/tests/Feature/PaymentTest.php
@@ -29,8 +29,6 @@ class PaymentTest extends TestCase
 
     /**
      * Check a payment's JSON representation for accuracy.
-     *
-     * @param  string  $payable_type
      */
     public static function checkPaymentJson(
         User $user,
@@ -38,7 +36,7 @@ class PaymentTest extends TestCase
         bool $isTravelAssignmentPayable,
         string $expectedPayableType,
         string $expectedPayableName,
-        int|float $expectedPayableCost,
+        float $expectedPayableCost,
         string $expectedPaymentMethodPresentation,
         bool $expectPrivilegedRecordedByUserInfo = false,
         bool $allowUnexpectedProps = true
@@ -56,7 +54,7 @@ class PaymentTest extends TestCase
         ) {
             $base = $json->has('id')
                 ->where('payable_type', $expectedPayableType)
-                ->where('amount', $expectedPayableCost)
+                ->where('amount', static fn (string $amount) => (float) $amount === $expectedPayableCost)
                 ->where('method_presentation', $expectedPaymentMethodPresentation)
                 ->where('recorded_by_user.name', static fn (?string $name) => $name !== null && strlen($name) > 0);
 


### PR DESCRIPTION
The `amount` field on a Payment object is a string, so this switches to a function check for the JSON field so we can cast it to a float. I was able to reproduce a failure case for the test that occurred when a dues package price was an integer with no decimal places, e.g., 921. The issue comes up only occasionally since we use a random price for the dues package in test. To resolve, I swapped to a closure to check the JSON field and adjusted to cast the `amount` field from the payment to a float.