### PR TITLE
Nova UX improvements for packages and transactions

### DIFF
--- a/app/Nova/DuesPackage.php
+++ b/app/Nova/DuesPackage.php
@@ -18,6 +18,7 @@ use Laravel\Nova\Fields\Boolean;
 use Laravel\Nova\Fields\Currency;
 use Laravel\Nova\Fields\DateTime;
 use Laravel\Nova\Fields\HasMany;
+use Laravel\Nova\Fields\Heading;
 use Laravel\Nova\Fields\Number;
 use Laravel\Nova\Fields\Select;
 use Laravel\Nova\Fields\Text;
@@ -90,6 +91,16 @@ class DuesPackage extends Resource
     public function fields(Request $request): array
     {
         return [
+            Heading::make(
+                '<strong>In general, dues packages should not be created manually.</strong> '.
+                'Use the <strong>Create Dues Packages</strong> action on a Fiscal Year to create default packages, '.
+                'then update as needed.'
+            )
+                ->asHtml()
+                ->showOnCreating(true)
+                ->showOnUpdating(false)
+                ->showOnDetail(false),
+
             Text::make('Name')
                 ->sortable()
                 ->rules('required', 'max:255')

--- a/app/Nova/DuesTransaction.php
+++ b/app/Nova/DuesTransaction.php
@@ -9,6 +9,7 @@ use Illuminate\Http\Request;
 use Laravel\Nova\Fields\BelongsTo;
 use Laravel\Nova\Fields\BelongsToMany;
 use Laravel\Nova\Fields\Currency;
+use Laravel\Nova\Fields\Heading;
 use Laravel\Nova\Fields\ID;
 use Laravel\Nova\Fields\MorphMany;
 use Laravel\Nova\Fields\Text;
@@ -71,6 +72,15 @@ class DuesTransaction extends Resource
     public function fields(NovaRequest $request): array
     {
         return [
+            Heading::make(
+                '<strong>In general, dues transactions should not be created manually.</strong> '.
+                'Dues transactions are created as part of the dues workflow in the member-facing UI.'
+            )
+                ->asHtml()
+                ->showOnCreating(true)
+                ->showOnUpdating(false)
+                ->showOnDetail(false),
+
             ID::make(),
 
             BelongsTo::make('Paid By', 'user', User::class)
@@ -170,7 +180,7 @@ class DuesTransaction extends Resource
     // This hides the edit button from indexes. This is here to hide the edit button on the merchandise pivot.
     public function authorizedToUpdateForSerialization(NovaRequest $request): bool
     {
-        return $request->user()->can('update-dues-transactions') && $request->viaResource !== 'merchandise';
+        return false;
     }
 
     /**

--- a/app/Policies/DuesTransactionPolicy.php
+++ b/app/Policies/DuesTransactionPolicy.php
@@ -29,7 +29,7 @@ class DuesTransactionPolicy
 
     public function update(User $user, DuesTransaction $resource): bool
     {
-        return $user->can('update-dues-transactions');
+        return false;
     }
 
     public function delete(User $user, DuesTransaction $resource): bool

--- a/database/migrations/2023_07_04_052659_remove_create_dues_packages_permission_from_officers.php
+++ b/database/migrations/2023_07_04_052659_remove_create_dues_packages_permission_from_officers.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Spatie\Permission\Models\Permission;
+use Spatie\Permission\Models\Role;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        app()['cache']->forget('spatie.permission.cache');
+
+        $officer = Role::where('name', '=', 'officer')->first();
+
+        $create_dues_packages = Permission::where('name', '=', 'create-dues-packages')->first();
+
+        if ($create_dues_packages !== null && $officer !== null) {
+            $officer->revokePermissionTo($create_dues_packages);
+        }
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        app()['cache']->forget('spatie.permission.cache');
+
+        $create_dues_packages = Permission::firstOrCreate(['name' => 'create-dues-packages']);
+
+        Role::firstOrCreate(['name' => 'officer'])->givePermissionTo($create_dues_packages);
+    }
+};

--- a/docs/officers/dues/data-model.rst
+++ b/docs/officers/dues/data-model.rst
@@ -34,7 +34,7 @@ Additional attributes are used to determine whether a package may be offered to 
 A :guilabel:`Dues Package` may also have links to one or more :ref:`Merchandise` objects, which may be selected by members when choosing that package.
 
 .. attention::
-   Packages generally should not be created manually by officers; there is a :ref:`action on Fiscal Years<Create Dues Packages>` that sets up default packages.
+   Packages generally should not be created manually by officers; there is an :ref:`action on Fiscal Years<Create Dues Packages>` that sets up default packages.
 
 Merchandise
 -----------

--- a/docs/officers/dues/data-model.rst
+++ b/docs/officers/dues/data-model.rst
@@ -33,6 +33,9 @@ Additional attributes are used to determine whether a package may be offered to 
 
 A :guilabel:`Dues Package` may also have links to one or more :ref:`Merchandise` objects, which may be selected by members when choosing that package.
 
+.. attention::
+   Packages generally should not be created manually by officers; there is a :ref:`action on Fiscal Years<Create Dues Packages>` that sets up default packages.
+
 Merchandise
 -----------
 


### PR DESCRIPTION
- Add banners to dues package and dues transaction creation to discourage manual creation
- Remove `create-dues-packages` permissions from `officer` role (`admin` still has it)
- Disable editing dues transactions for all users