### PR TITLE
Migrate merchandise distribution docs from wiki

### DIFF
--- a/app/Nova/Merchandise.php
+++ b/app/Nova/Merchandise.php
@@ -132,7 +132,7 @@ class Merchandise extends Resource
                     static fn (NovaRequest $request, AppModelsMerchandise $merchandise): bool => $request->user()->can(
                         'distribute-swag'
                     )
-                )->confirmButtonText('Mark as Picked Up')
+                )
                 ->onlyOnDetail(),
         ];
     }

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -15,6 +15,7 @@ Apiary Documentation
    officers/attendance
    officers/dues/index
    officers/payments/index
+   officers/merchandise
 
 .. toctree::
    :caption: For Administrators

--- a/docs/officers/attendance.rst
+++ b/docs/officers/attendance.rst
@@ -6,7 +6,7 @@ Attendance
 Apiary supports recording attendance for both in-person and online meetings, using either BuzzCards or links.
 
 .. hint::
-   To use either method, you must have a team lead, trainer, project manager, or officer role.
+   To use either method, you must have a ``team-lead``, ``trainer``, ``project-manager``, or ``officer`` role.
    If you need access, ask in :slack:`it-helpdesk`.
 
 In-Person Meetings

--- a/docs/officers/merchandise.rst
+++ b/docs/officers/merchandise.rst
@@ -1,0 +1,40 @@
+:og:description: RoboJackets members who pay dues are eligible to recieve merchandise, such as a t-shirt or polo. When you physically give someone merchandise, you must record it in Apiary.
+.. meta::
+   :keywords: swag
+
+Merchandise
+===========
+
+RoboJackets members who pay dues are eligible to receive merchandise, such as a t-shirt or polo.
+When you physically give someone merchandise, you must record it in Apiary.
+
+When a student pays for a dues package that is restricted to students (rather than a non-student package), they are offered a choice of merchandise attached to the package.
+
+.. hint::
+   To reccord distribution or view transactions, you must have a ``team-lead``, ``project-manager``, or ``officer`` role.
+   If you need access, ask in :slack:`it-helpdesk`.
+
+Confirming Merchandise Selections
+---------------------------------
+
+To confirm which merchandise a member selected when they pay dues, follow these steps.
+
+#. From the Apiary homepage, click the :guilabel:`Admin` link in the top navigation bar.
+#. Under the :guilabel:`Other` header in the left sidebar, click :guilabel:`Users`.
+#. Search for the member using the search box under the :guilabel:`Users` header, then select the user from the results.
+#. Scroll to the :guilabel:`Dues Transactions` heading, and select the transaction for which you want to distribute merchandise.
+#. On the transaction detail page, scroll to the :guilabel:`Merchandise` heading.
+   This section lists the merchandise selections made when the member paid dues.
+#. To distribute an item, select it, then follow the steps in the next section.
+
+Recording Merchandise Distribution
+----------------------------------
+
+To record distribution of an item, follow these steps.
+
+#. Open the details page for the merchandise item you want to distribute.
+   You can either use the steps in the section above, or look at the :guilabel:`Merchandise` list under the :guilabel:`Dues` heading in the left sidebar.
+#. Click the Actions menu (three dots |actionsmenu|) to the right of the :guilabel:`Merchandise Details` header, then select the :guilabel:`Distribute Merchandise` option.
+#. Search for the user you're distributing merchandise to, then click :guilabel:`Mark as Picked Up`.
+   If you do not see the user's name in the list, they may not be eligible to receive the item, or they may not have selected it when they paid dues.
+   You can ask in :slack:`it-helpdesk` if you're not sure.


### PR DESCRIPTION
- Migrate [How to Distribute Swag](https://wiki.robojackets.org/How_to_Distribute_Swag) to Sphinx docs [[view rendered page](https://apiary-sandbox.robojackets.org/docs/officers/merchandise/)]
- Remove "Distributed By" field from Nova popup to simplify UX

Progress towards #3577