### PR TITLE
Add documentation for export functions

### DIFF
--- a/app/Nova/Actions/ExportDemographicsSurveyRecipients.php
+++ b/app/Nova/Actions/ExportDemographicsSurveyRecipients.php
@@ -33,6 +33,7 @@ class ExportDemographicsSurveyRecipients extends Action
     {
         $users = User::active()
             ->whereNull('email_suppression_reason')
+            ->where('is_service_account', '=', false)
             ->get();
 
         if (count($users) === 0) {

--- a/app/Nova/Actions/ExportResumes.php
+++ b/app/Nova/Actions/ExportResumes.php
@@ -163,6 +163,7 @@ class ExportResumes extends Action
                 ->active()
                 ->whereNotNull('resume_date')
                 ->where('primary_affiliation', 'student')
+                ->where('is_service_account', '=', false)
                 ->whereDoesntHave('duesPackages', static function (Builder $q): void {
                     $q->where('restricted_to_students', false);
                 })
@@ -190,6 +191,7 @@ class ExportResumes extends Action
             ->active()
             ->whereNotNull('resume_date')
             ->where('primary_affiliation', 'student')
+            ->where('is_service_account', '=', false)
             ->whereDoesntHave('duesPackages', static function (Builder $q): void {
                 $q->where('restricted_to_students', false);
             })
@@ -232,7 +234,7 @@ class ExportResumes extends Action
                 ->required(),
 
             // "before:yesterday" stops users from putting in a date that doesn't make sense that will generate an
-            // empty output. "yesterday" is either 7PM or 8PM yesterdady, depending on timezones (EST vs EDT).
+            // empty output. "yesterday" is either 7PM or 8PM yesterday, depending on timezones (EST vs EDT).
             Date::make('Resume Date Cutoff')
                 ->help('Only include resumes uploaded after this date. This should generally be the start date of the'.
                     ' fall semester. When users upload a resume, all older resumes are deleted.')

--- a/app/Nova/Actions/ExportUsersBuzzCardAccess.php
+++ b/app/Nova/Actions/ExportUsersBuzzCardAccess.php
@@ -39,7 +39,9 @@ class ExportUsersBuzzCardAccess extends Action
     public function handle(ActionFields $fields, Collection $models)
     {
         $population = $fields->population;
-        $users = User::select('gtid', 'first_name', 'last_name')->buzzCardAccessEligible()
+        $users = User::select('gtid', 'first_name', 'last_name')
+            ->buzzCardAccessEligible()
+            ->where('is_service_account', '=', false)
             ->when(
                 $population === 'core',
                 static function (Builder $q): void {

--- a/docs/.proselintrc.json
+++ b/docs/.proselintrc.json
@@ -74,7 +74,7 @@
         "terms.denizen_labels": true,
         "terms.eponymous_adjectives": true,
         "terms.venery": true,
-        "typography.diacritical_marks": true,
+        "typography.diacritical_marks": false,
         "typography.exclamation": true,
         "typography.symbols": false,
         "uncomparables.misc": true,

--- a/docs/.styles/Vocab/RoboJackets/accept.txt
+++ b/docs/.styles/Vocab/RoboJackets/accept.txt
@@ -15,3 +15,4 @@ OAuth
 expiration
 JWT
 RSVPs
+Qualtrics

--- a/docs/admins/api/endpoints.rst
+++ b/docs/admins/api/endpoints.rst
@@ -8,7 +8,7 @@ Endpoints
 This list includes the endpoints that are most heavily used and maintained, but isn't comprehensive.
 If you're looking for an endpoint to perform a specific operation not listed here, ask in :slack:`apiary`.
 
-All endpoints require an ``Authorization`` header with an OAuth access token, and an ``Accept`` header set to ``application/json``.
+All endpoints require an ``Authorization`` header with an OAuth access token, and an ``Accept`` header set to ``application/json``. See :doc:`/admins/api/auth` for more information.
 
 .. http:get:: /api/v1/user
    :synopsis: Returns information about the authenticated user
@@ -38,6 +38,8 @@ All endpoints require an ``Authorization`` header with an OAuth access token, an
 .. http:put:: /api/v1/users/(str:identifier)
    :synopsis: Updates a specific user
 
+   :parameter string identifier: either a GTID, GT username, or Apiary ID
+
    :requestheader Authorization: an OAuth access token (see :ref:`Authentication`)
    :requestheader Accept: ``application/json``
 
@@ -64,7 +66,7 @@ All endpoints require an ``Authorization`` header with an OAuth access token, an
    :requestheader Authorization: an OAuth access token (see :ref:`Authentication`)
    :requestheader Accept: ``application/json``
 
-   :status 200: the update was successful and the new information is returned
+   :status 200: an array of user information is returned
    :status 401: the token was either not provided or invalid
    :status 403: the authenticated user does not have permission for this operation (``read-users``)
 

--- a/docs/admins/permissions-roles.rst
+++ b/docs/admins/permissions-roles.rst
@@ -33,7 +33,10 @@ This role grants access to almost all functions and should only be assigned to s
 ``officer``
 ~~~~~~~~~~~
 
+.. vale Google.Parens = NO
+
 - View users, :ref:`dues transactions <Dues Transaction>`, and :doc:`payments </officers/payments/index>`
+- View and export :abbr:`GTIDs (Georgia Tech Identification Number)`
 - Create and update :ref:`dues packages <Dues Package>`
 - Create and update :doc:`events </officers/events>`
 - :doc:`Take attendance for any team or event </officers/attendance>`

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -14,10 +14,11 @@ Apiary
    :caption: For Officers
 
    officers/attendance
-   officers/events
    officers/dues/index
-   officers/payments/index
+   officers/events
    officers/merchandise
+   officers/payments/index
+   officers/users
 
 .. toctree::
    :caption: For Administrators

--- a/docs/officers/attendance.rst
+++ b/docs/officers/attendance.rst
@@ -6,7 +6,7 @@ Attendance
 Apiary supports recording attendance for both in-person and online meetings, using either BuzzCards or links.
 
 .. hint::
-   To use either method, you must have a :ref:`officer`, :ref:`project-manager`, :ref:`team-lead`, or :ref:`trainer` role.
+   To use either method, you must have an :ref:`officer`, :ref:`project-manager`, :ref:`team-lead`, or :ref:`trainer` role.
    If you need access, ask in :slack:`it-helpdesk`.
 
 In-person meetings

--- a/docs/officers/users.rst
+++ b/docs/officers/users.rst
@@ -1,0 +1,90 @@
+:og:description: Apiary represents individuals, both members and non-members, as User records that link to all other information associated with that individual. Officers can generate commonly used reports about members.
+
+Users
+=====
+
+Apiary represents individuals, both members and non-members, as :guilabel:`User` records that link to all other information associated with that individual.
+Officers can generate commonly used reports about members.
+
+Export resumes
+--------------
+
+.. vale Google.Parens = NO
+.. vale Google.Passive = NO
+.. vale Google.Will = NO
+.. vale proselint.Diacritical = NO
+.. vale write-good.E-Prime = NO
+.. vale write-good.Passive = NO
+.. vale write-good.Weasel = NO
+
+Apiary allows active members to upload a resume within the member-facing interface.
+Officers can then generate a resume book to send to sponsors.
+
+The resume book only includes active members.
+Any filters applied to the user list outside of the popup are ignored.
+
+.. hint::
+   This export requires the ``read-users-resume`` permission, which is included in the :ref:`officer` and :ref:`admin` roles.
+   If you need access, ask in :slack:`it-helpdesk`.
+
+To export resumes:
+
+#. From the Apiary homepage, click the :guilabel:`Admin` link in the top navigation bar.
+#. Under the :guilabel:`Other` header in the left sidebar, click :guilabel:`Users`.
+#. Click the Actions menu (three dots |actionsmenu|) in the top right corner, then select :guilabel:`Export Resumes`.
+   A popup will appear.
+#. Select the majors and class standings you want to include with this report, and the date cutoff to exclude old resumes.
+   **Note that any filters selected outside of the popup are ignored.**
+   The popup will only show majors and class standings for active members that have uploaded resumes.
+#. Click :guilabel:`Export Resumes`, then wait.
+   This may take several seconds depending on how many resumes are included.
+
+All resumes that match the criteria are combined into a single :abbr:`PDF (Portable Document Format)` and downloaded.
+Review the PDF before distributing it to sponsors.
+
+.. vale Google.Headings = NO
+
+Export BuzzCard access list
+---------------------------
+
+This function generates a :abbr:`CSV (comma-separated values)` file that Mechanical Engineering Facilities needs to grant BuzzCard access to the Student Competition Center and the RoboJackets shop.
+
+.. hint::
+   This export requires the ``read-users-gtid`` permission, which is only included in the :ref:`admin` role.
+   If you need access, ask in :slack:`it-helpdesk`.
+
+The CSV file includes members meeting the following criteria. Any filters applied to the user list are ignored.
+
+* Must be access active
+* Must be a current student, faculty, or staff, as determined by Georgia Tech
+* Must not have paid for any dues packages that are **not** :guilabel:`Restricted to Students`
+* Must not have the :guilabel:`BuzzCard Access Opt-Out` flag applied
+
+To generate the list:
+
+#. From the Apiary homepage, click the :guilabel:`Admin` link in the top navigation bar.
+#. Under the :guilabel:`Other` header in the left sidebar, click :guilabel:`Users`.
+#. Click the Actions menu (three dots |actionsmenu|) in the top right corner, then select :guilabel:`Export BuzzCard Access List`.
+   A popup will appear.
+#. Select the population that you want to export.
+   The :guilabel:`Core` population only includes members within the Core team, and the :guilabel:`General` population only includes members that **aren't** within the Core team.
+   You should generate lists for **both** populations and send **both** to Mechanical Engineering Facilities, but the export can only generate one at a time due to technical limitations.
+#. Click :guilabel:`Export List`.
+
+Export demographics survey recipients
+-------------------------------------
+
+This function generates a CSV file of email addresses that can be imported to Qualtrics for the annual demographics survey.
+
+.. I'm not going to include an access hint here because it's restricted to read-users and that's included with all roles that have access to Nova.
+
+The CSV file only includes active members without an email suppression. Any filters applied to the user list are ignored.
+
+.. note::
+   `Postmark <https://postmarkapp.com/>`_ applies an email suppression when an email address bounces, or if a user explicitly unsubscribes from Apiary emails.
+
+To generate the list:
+
+#. From the Apiary homepage, click the :guilabel:`Admin` link in the top navigation bar.
+#. Under the :guilabel:`Other` header in the left sidebar, click :guilabel:`Users`.
+#. Click the Actions menu (three dots |actionsmenu|) in the top right corner, then select :guilabel:`Export Demographics Survey Recipients`.

--- a/docs/officers/users.rst
+++ b/docs/officers/users.rst
@@ -20,12 +20,13 @@ Export resumes
 Apiary allows active members to upload a resume within the member-facing interface.
 Officers can then generate a resume book to send to sponsors.
 
-The resume book only includes active members.
-Any filters applied to the user list outside of the popup are ignored.
-
 .. hint::
    This export requires the ``read-users-resume`` permission, which is included in the :ref:`officer` and :ref:`admin` roles.
    If you need access, ask in :slack:`it-helpdesk`.
+
+
+The resume book only includes active members.
+Any filters applied to the user list outside of the popup are ignored.
 
 To export resumes:
 
@@ -47,7 +48,7 @@ Review the PDF before distributing it to sponsors.
 Export BuzzCard access list
 ---------------------------
 
-This function generates a :abbr:`CSV (comma-separated values)` file that Mechanical Engineering Facilities needs to grant BuzzCard access to the Student Competition Center and the RoboJackets shop.
+This export generates a :abbr:`CSV (comma-separated values)` file that Mechanical Engineering Facilities needs to grant BuzzCard access to the Student Competition Center and the RoboJackets shop.
 
 .. hint::
    This export requires the ``read-users-gtid`` permission, which is only included in the :ref:`admin` role.
@@ -74,14 +75,17 @@ To generate the list:
 Export demographics survey recipients
 -------------------------------------
 
-This function generates a CSV file of email addresses that can be imported to Qualtrics for the annual demographics survey.
+This export generates a CSV file of email addresses that can be imported to Qualtrics for the annual demographics survey.
 
-.. I'm not going to include an access hint here because it's restricted to read-users and that's included with all roles that have access to Nova.
+.. hint::
+   This export is available to everyone with access to the administrative interface.
+   If you need access, ask in :slack:`it-helpdesk`.
 
-The CSV file only includes active members without an email suppression. Any filters applied to the user list are ignored.
+The CSV file only includes active members without an email suppression.
+Any filters applied to the user list are ignored.
 
 .. note::
-   `Postmark <https://postmarkapp.com/>`_ applies an email suppression when an email address bounces, or if a user explicitly unsubscribes from Apiary emails.
+   Apiary automatically applies an email suppression when an email address bounces, or if a user explicitly unsubscribes from Apiary emails.
 
 To generate the list:
 


### PR DESCRIPTION
- Explicitly remove service accounts from all exports - they probably aren't being included now but may as well be safe
- Fix some API endpoint documentation
- Add documentation for user exports (resumes, BuzzCard, demographics survey) - [rendered docs here](https://apiary-sandbox.robojackets.org/docs/officers/users/)

Progress towards #3577 