### PR TITLE
Simplify Nova for non-admins

### DIFF
--- a/app/Nova/ClassStanding.php
+++ b/app/Nova/ClassStanding.php
@@ -68,4 +68,12 @@ class ClassStanding extends Resource
             self::metadataPanel(),
         ];
     }
+
+    /**
+     * Determine if this resource is available for navigation.
+     */
+    public static function availableForNavigation(Request $request): bool
+    {
+        return $request->user()->hasRole('admin');
+    }
 }

--- a/app/Nova/Major.php
+++ b/app/Nova/Major.php
@@ -101,4 +101,12 @@ class Major extends Resource
             new MajorsMissingDisplayNames(),
         ];
     }
+
+    /**
+     * Determine if this resource is available for navigation.
+     */
+    public static function availableForNavigation(Request $request): bool
+    {
+        return $request->user()->hasRole('admin');
+    }
 }

--- a/app/Nova/Payment.php
+++ b/app/Nova/Payment.php
@@ -48,13 +48,6 @@ class Payment extends Resource
     ];
 
     /**
-     * Indicates if the resource should be displayed in the sidebar.
-     *
-     * @var bool
-     */
-    public static $displayInNavigation = false;
-
-    /**
      * Indicates if the resource should be globally searchable.
      *
      * @var bool
@@ -276,5 +269,13 @@ class Payment extends Resource
     public static function searchable(): bool
     {
         return false;
+    }
+
+    /**
+     * Determine if this resource is available for navigation.
+     */
+    public static function availableForNavigation(Request $request): bool
+    {
+        return $request->user()->hasRole('admin');
     }
 }

--- a/app/Nova/User.php
+++ b/app/Nova/User.php
@@ -486,24 +486,30 @@ class User extends Resource
     {
         return [
             DateTime::make('Account Created', 'created_at')
+                ->canSee(static fn (Request $request): bool => $request->user()->hasRole('admin'))
                 ->onlyOnDetail(),
 
             DateTime::make('Last Updated', 'updated_at')
+                ->canSee(static fn (Request $request): bool => $request->user()->hasRole('admin'))
                 ->onlyOnDetail(),
 
             Boolean::make('Has Ever Logged In')
+                ->canSee(static fn (Request $request): bool => $request->user()->hasRole('admin'))
                 ->onlyOnDetail(),
 
             Boolean::make('Is Service Account')
+                ->canSee(static fn (Request $request): bool => $request->user()->hasRole('admin'))
                 ->hideFromIndex(),
 
             Text::make('Create Reason')
+                ->canSee(static fn (Request $request): bool => $request->user()->hasRole('admin'))
                 ->hideWhenUpdating()
                 ->hideFromIndex()
                 ->required()
                 ->rules('required'),
 
             Text::make('gtDirGUID', 'gtDirGUID')
+                ->canSee(static fn (Request $request): bool => $request->user()->hasRole('admin'))
                 ->hideWhenCreating()
                 ->hideFromIndex()
                 ->copyable(),

--- a/app/Policies/DocuSignEnvelopePolicy.php
+++ b/app/Policies/DocuSignEnvelopePolicy.php
@@ -19,7 +19,9 @@ class DocuSignEnvelopePolicy
      */
     public function viewAny(User $user): bool
     {
-        return $user->can('view-docusign-envelopes') || Travel::where('primary_contact_user_id', $user->id)->exists();
+        return $user->can('view-docusign-envelopes') ||
+            Travel::where('primary_contact_user_id', $user->id)->exists() ||
+            DocuSignEnvelope::where('sent_by', $user->id)->exists();
     }
 
     /**
@@ -28,6 +30,7 @@ class DocuSignEnvelopePolicy
     public function view(User $user, DocuSignEnvelope $docuSignEnvelope): bool
     {
         return $user->can('view-docusign-envelopes') ||
+            $docuSignEnvelope->sent_by === $user->id ||
             (
                 $docuSignEnvelope->signable_type === TravelAssignment::getMorphClassStatic() &&
                 $docuSignEnvelope->signable->travel->primaryContact->id === $user->id

--- a/database/migrations/2023_12_28_124458_remove_read_payments_permission_from_team_lead_role.php
+++ b/database/migrations/2023_12_28_124458_remove_read_payments_permission_from_team_lead_role.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Spatie\Permission\Models\Permission;
+use Spatie\Permission\Models\Role;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        app()['cache']->forget('spatie.permission.cache');
+
+        $team_lead = Role::where('name', '=', 'team-lead')->first();
+
+        $read_payments = Permission::where('name', '=', 'read-payments')->first();
+
+        if ($read_payments !== null && $team_lead !== null) {
+            $team_lead->revokePermissionTo($read_payments);
+        }
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        app()['cache']->forget('spatie.permission.cache');
+
+        $read_payments = Permission::firstOrCreate(['name' => 'read-payments']);
+
+        Role::firstOrCreate(['name' => 'team-lead'])->givePermissionTo($read_payments);
+    }
+};


### PR DESCRIPTION
This pull request closes #3974.

- Class Standings, Majors, and Payments will only appear in the navigation sidebar for admins
- User metadata fields will only appear for admins
- DocuSign envelope senders can view the envelopes they sent
- `team-lead` role can no longer view payments