### PR TITLE
Add Google Form support to RALs

### DIFF
--- a/app/Models/RemoteAttendanceLink.php
+++ b/app/Models/RemoteAttendanceLink.php
@@ -76,12 +76,13 @@ class RemoteAttendanceLink extends Model
      * https://meet.google.com/<alpha and dashes>
      * https://teams.microsoft.com/l/meetup-join/<alphanumeric, -, %, .>/<digits>
      * https://gatech.zoom.us/j/<digits>
+     * https://forms.gle/<alphanumeric>
      * but nothing else, to avoid users redirecting to surprising things.
      *
      * @phan-suppress PhanReadOnlyPublicProperty
      */
     public static string $redirectRegex = '/^(https?:\/\/)?(meet\.google\.com\/[-a-z]+|teams\.microsoft\.com\/l\/'
-        .'meetup-join\/[-a-zA-Z0-9%\._]+\/[0-9]+|gatech\.zoom\.us\/j\/[0-9]+)(\?[^@]*)?$/';
+        .'meetup-join\/[-a-zA-Z0-9%\._]+\/[0-9]+|gatech\.zoom\.us\/j\/[0-9]+|forms\.gle\/[a-zA-Z0-9])(\?[^@]*)?$/';
 
     /**
      * Get the attributes that should be cast.
@@ -100,8 +101,6 @@ class RemoteAttendanceLink extends Model
      */
     public static function normalizeRedirectUrl(string $url): string
     {
-        $url = Str::lower($url);
-
         if (Str::startsWith($url, 'https://')) {
             return $url;
         }

--- a/app/Nova/Actions/CreateRemoteAttendanceLink.php
+++ b/app/Nova/Actions/CreateRemoteAttendanceLink.php
@@ -87,8 +87,8 @@ class CreateRemoteAttendanceLink extends Action
             Text::make('Redirect URL')
                 ->required(false)
                 ->rules('nullable', 'regex:'.RemoteAttendanceLink::$redirectRegex, 'max:1023')
-                ->help('If you put a link to a Google Meet, Zoom, or Microsoft Teams meeting or a Google Forms short URL '.
-                    'here, everyone who clicks the attendance link will be redirected to that meeting after their '.
+                ->help('If you put a link to a Google Meet, Zoom, or Microsoft Teams meeting or a Google Forms short '.
+                    'URL here, everyone who clicks the attendance link will be redirected to that meeting after their '.
                     'attendance is recorded. If you add a redirect URL, do not share that URL directly. Only Google '.
                     'Meet, Zoom, and Microsoft Teams calls and Google Forms are supported currently. Ask in '.
                     '#it-helpdesk for other redirect URLs.'),

--- a/app/Nova/Actions/CreateRemoteAttendanceLink.php
+++ b/app/Nova/Actions/CreateRemoteAttendanceLink.php
@@ -87,11 +87,11 @@ class CreateRemoteAttendanceLink extends Action
             Text::make('Redirect URL')
                 ->required(false)
                 ->rules('nullable', 'regex:'.RemoteAttendanceLink::$redirectRegex, 'max:1023')
-                ->help('If you put a link to a Google Meet, Zoom, or Microsoft Teams meeting here, '.
-                    'everyone who clicks the attendance link will be redirected to that meeting after their '.
+                ->help('If you put a link to a Google Meet, Zoom, or Microsoft Teams meeting or a Google Forms short URL '.
+                    'here, everyone who clicks the attendance link will be redirected to that meeting after their '.
                     'attendance is recorded. If you add a redirect URL, do not share that URL directly. Only Google '.
-                    'Meet, Zoom, and Microsoft Teams calls are supported currently. Ask in #it-helpdesk for'.
-                    ' other redirect URLs.'),
+                    'Meet, Zoom, and Microsoft Teams calls and Google Forms are supported currently. Ask in '.
+                    '#it-helpdesk for other redirect URLs.'),
 
             Select::make('Purpose')
                 ->required(true)

--- a/tests/Unit/RemoteAttendanceLinkTest.php
+++ b/tests/Unit/RemoteAttendanceLinkTest.php
@@ -63,6 +63,16 @@ final class RemoteAttendanceLinkTest extends TestCase
         $this->redirectRegexTestCase('gatech.zoom.us/j/12345?query@query', false);
     }
 
+    /**
+     * Test Google Form links.
+     */
+    public function testRedirectRegexGoogleForm(): void
+    {
+        $this->redirectRegexTestCase('forms.gle/4PfXD3rUh8', true);
+
+        $this->redirectRegexTestCase('forms.gle/4PfXD3rU&h8-', false);
+    }
+
     private function redirectRegexTestCase(string $url, bool $expected): void
     {
         if ($expected) {


### PR DESCRIPTION
As requested by mech training lead, support Google Forms short URLs for remote attendance link redirects. They're making QR codes and want to send people to a survey.