### PR TITLE
Port over nicer job failure Slack messages from Jedi

### DIFF
--- a/app/Util/JobFailureNotification.php
+++ b/app/Util/JobFailureNotification.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Util;
+
+use Illuminate\Notifications\Messages\SlackAttachment;
+use Illuminate\Notifications\Messages\SlackMessage;
+use Spatie\FailedJobMonitor\Notification;
+
+class JobFailureNotification extends Notification
+{
+    #[\Override]
+    public function toSlack(): SlackMessage
+    {
+        $job_name_parts = explode('\\', $this->event->job->resolveName());
+        $job_name = $job_name_parts[count($job_name_parts) - 1];
+
+        return (new SlackMessage())
+            ->error()
+            ->attachment(function (SlackAttachment $attachment) use ($job_name): void {
+                $attachment
+                    ->title(
+                        $job_name.' failed',
+                        config('app.url').'/horizon/failed/'.$this->event->job->uuid()
+                    )
+                    ->fallback($job_name.' failed')
+                    ->fields([
+                        'Exception' => $this->event->exception->getMessage(),
+                        'Job' => $job_name,
+                    ]);
+            });
+    }
+}

--- a/config/failed-job-monitor.php
+++ b/config/failed-job-monitor.php
@@ -7,7 +7,7 @@ return [
     /*
      * The notification that will be sent when a job fails.
      */
-    'notification' => \Spatie\FailedJobMonitor\Notification::class,
+    'notification' => \App\Util\JobFailureNotification::class,
 
     /*
      * The notifiable to which the notification will be sent. The default


### PR DESCRIPTION
This PR ports the job failure slack messages from Jedi, as suggested in the original issue.


Closes https://github.com/RoboJackets/apiary/issues/3926