### PR TITLE
Check for team exists before calculate active members count

### DIFF
--- a/app/Nova/Metrics/ActiveMembers.php
+++ b/app/Nova/Metrics/ActiveMembers.php
@@ -25,7 +25,8 @@ class ActiveMembers extends Value
     public function calculate(Request $request): ValueResult
     {
         if (isset($request->resourceId)) {
-            $count = Team::where('id', $request->resourceId)
+            $count = Team::withTrashed()
+                ->where('id', $request->resourceId)
                 ->first()
                 ->members()
                 ->active()


### PR DESCRIPTION
This PR aims to fix the issue https://github.com/RoboJackets/apiary/issues/3494 by checking if the team exists before trying to get active members count, and if it does not exists, return 0.


Closes https://github.com/RoboJackets/apiary/issues/3494 if approved.