### PR TITLE
Check for team exists before calculate total members count

### DIFF
--- a/app/Nova/Metrics/TotalTeamMembers.php
+++ b/app/Nova/Metrics/TotalTeamMembers.php
@@ -23,7 +23,11 @@ class TotalTeamMembers extends Value
      */
     public function calculate(Request $request): ValueResult
     {
-        $count = Team::where('id', $request->resourceId)->first()->members()->count();
+        $count = Team::withTrashed()
+            ->where('id', $request->resourceId)
+            ->first()
+            ->members()
+            ->count();
 
         return $this->result($count)->allowZeroResult();
     }


### PR DESCRIPTION
This PR aims to fix the issue https://github.com/RoboJackets/apiary/issues/3493 by checking if the team exists before trying to get total members count, and if it does not exists, return 0.


Closes https://github.com/RoboJackets/apiary/issues/3493 if approved.