### PR TITLE
Kiosk Card Format Updates

### DIFF
--- a/app/Http/Controllers/AttendanceController.php
+++ b/app/Http/Controllers/AttendanceController.php
@@ -80,7 +80,8 @@ class AttendanceController implements HasMiddleware
         } else {
             $user = null;
             $attExistingQ = Attendance::where(
-                $request->only(['attendable_type', 'attendable_id', 'access_card_number']))
+                $request->only(['attendable_type', 'attendable_id', 'access_card_number'])
+            )
                 ->whereDate('created_at', $date);
             $identifier = ['key' => 'access_card_number', 'value' => $request->input('access_card_number')];
         }

--- a/app/Http/Controllers/AttendanceController.php
+++ b/app/Http/Controllers/AttendanceController.php
@@ -66,16 +66,26 @@ class AttendanceController implements HasMiddleware
                 $card = AccessCard::where('access_card_number', '=', $request->input('access_card_number'))->sole();
 
                 $gtid = $card->user->gtid;
+            } else {
+                Log::debug(self::class.': Could not resolve GTID for access card '.$request->input('access_card_number'));
             }
         }
 
-        $user = User::where('gtid', '=', $gtid)->first();
+        if ($gtid !== null) {
+            $user = User::where('gtid', '=', $gtid)->first();
+            $attExistingQ = Attendance::where($request->only(['attendable_type', 'attendable_id']))
+                ->where('gtid', '=', $gtid)->whereDate('created_at', $date);
+            $identifier = ['key' => 'gtid', 'value' => $gtid];
+        } else {
+            $user = null;
+            $attExistingQ = Attendance::where($request->only(['attendable_type', 'attendable_id', 'access_card_number']))
+                ->whereDate('created_at', $date);
+            $identifier = ['key' => 'access_card_number', 'value' => $request->input('access_card_number')];
+        }
 
-        $attExistingQ = Attendance::where($request->only(['attendable_type', 'attendable_id', 'gtid']))
-            ->whereDate('created_at', $date);
         $attExistingCount = $attExistingQ->count();
         if ($attExistingCount > 0) {
-            Log::debug(self::class.': Found a swipe on '.$date.' for '.$gtid.' - ignoring.');
+            Log::debug(self::class.': Found attendance on '.$date.' for '.$identifier['value'].' - ignoring.');
             $att = $attExistingQ->first();
             $code = 200;
 
@@ -83,13 +93,13 @@ class AttendanceController implements HasMiddleware
                 PushToJedi::dispatch($user, self::class, -1, 'duplicate-attendance');
             }
         } else {
-            Log::debug(self::class.': No swipe yet on '.$date.' for '.$gtid.' - saving.');
+            Log::debug(self::class.': No attendance yet on '.$date.' for '.$identifier['value'].' - saving.');
             $att = Attendance::create(
                 array_merge(
                     $request->validated(),
                     [
                         'recorded_by' => $request->user()->id,
-                        'gtid' => $gtid,
+                        $identifier['key'] => $identifier['value'],
                     ]
                 )
             );

--- a/app/Http/Controllers/AttendanceController.php
+++ b/app/Http/Controllers/AttendanceController.php
@@ -67,7 +67,8 @@ class AttendanceController implements HasMiddleware
 
                 $gtid = $card->user->gtid;
             } else {
-                Log::debug(self::class.': Could not resolve GTID for access card '.$request->input('access_card_number'));
+                Log::debug(self::class.': Could not resolve GTID for access card '.
+                    $request->input('access_card_number'));
             }
         }
 
@@ -78,7 +79,8 @@ class AttendanceController implements HasMiddleware
             $identifier = ['key' => 'gtid', 'value' => $gtid];
         } else {
             $user = null;
-            $attExistingQ = Attendance::where($request->only(['attendable_type', 'attendable_id', 'access_card_number']))
+            $attExistingQ = Attendance::where(
+                $request->only(['attendable_type', 'attendable_id', 'access_card_number']))
                 ->whereDate('created_at', $date);
             $identifier = ['key' => 'access_card_number', 'value' => $request->input('access_card_number')];
         }

--- a/app/Http/Resources/Attendance.php
+++ b/app/Http/Resources/Attendance.php
@@ -31,6 +31,7 @@ class Attendance extends JsonResource
                 UserOrClient::can('read-users-gtid'),
                 $this->gtid
             ),
+            'access_card_number' => $this->access_card_number,
             'source' => $this->source,
             'recorded_by' => new Manager($this->whenLoaded('recorded')),
             'created_at' => $this->created_at,

--- a/resources/js/components/attendance/AttendanceKiosk.vue
+++ b/resources/js/components/attendance/AttendanceKiosk.vue
@@ -296,8 +296,25 @@
             },
             submit() {
                 // Check for lack of team selection
-                if (this.attendance.attendable_id === '' && this.attendance.gtid !== '') {
-                    // We have a valid card read with GTID and no team picked, check if user is an admin for hidden menu access
+                if (this.attendance.attendable_id === '') {
+                    // We have a valid card read with and no team picked, check if user is an admin for hidden menu access
+                    if (this.attendance.gtid !== '') {
+                        // If there's no GTID, we can't query admin status, so assume they're not.
+                        this.hasError = true;
+                        this.feedback = '';
+                        this.clearFields();
+                        new Audio(this.sounds.error).play()
+                        Swal.fire({
+                          title: 'Whoops!',
+                          text: 'Select a team before tapping your BuzzCard',
+                          icon: 'warning',
+                          timer: 2500,
+                          timerProgressBar: true,
+                          showConfirmButton: false
+                        });
+                        return false;
+                    }
+
                     axios
                         .get(this.usersBaseUrl + "/search", {
                             params: {

--- a/resources/js/components/attendance/AttendanceKiosk.vue
+++ b/resources/js/components/attendance/AttendanceKiosk.vue
@@ -24,6 +24,7 @@
             return {
                 attendance: {
                     gtid: '',
+                    access_card_number: '',
                     attendable_id: '',
                     attendable_type: 'team',
                     source: 'kiosk',
@@ -144,7 +145,6 @@
                             buffer += e.key;
                         } else {
                             //Enter was pressed
-                            this.cardType = 'magstripe';
                             this.cardPresented(buffer);
                             buffer = '';
                         }
@@ -218,51 +218,60 @@
                 // Card is presented, process the data
                 let self = this;
                 this.attendance.source = 'kiosk';
-                console.log('first cardData: ' + cardData);
 
-                let pattTrackRaw = new RegExp('=(9[0-9]+)=');
-                let pattError = new RegExp('[%;+][eE]\\?');
-                let pattTrackNFC = new RegExp('NFC-(9[0-9]+)');
+                const mrd5Regex = /\|?(\d*)\|(\d+)\|(\w+)\|/;
+                const tsRawRegex = /^1570=(\d+)=\d+=(\d+)$/;
 
                 if (this.isNumeric(cardData) && cardData.length == 9 && cardData[0] == '9') {
-                    // Numeric nine-digit number starting with a nine
+                    // GTID only: no specific credential type discernible (e.g. 902900001)
                     this.attendance.gtid = cardData;
+                    cardData = null;
+                    this.submit();
+                } else if (this.isNumeric(cardData) && cardData.length == 16 && cardData.startsWith('601770')) {
+                    // Mobile credential: sixteen-digit number starting with 601770 (e.g. 6017700010000123)
+                    this.cardType = 'mobile';
+                    this.attendance.access_card_number = cardData;
                     this.attendance.source += '-' + this.cardType;
-                    console.log('numeric cardData: ' + cardData);
                     cardData = null;
                     this.submit();
-                } else if (pattTrackRaw.test(cardData)) {
-                    // Raw (unformatted) data from track 2 of the magnetic stripe
-                    let data = pattTrackRaw.exec(cardData)[1];
-                    console.log('raw cardData: ' + data);
-                    cardData = null;
-                    this.attendance.gtid = data;
+                } else if (this.isNumeric(cardData) && (cardData.length == 6 || cardData.length == 7 ||
+                  (cardData.length == 9 && cardData.startsWith('0')))) {
+                    // Plastic credential: 6-digit, 7-digit or 9-digit zero-padded
+                    // e.g. 800001, 1000003, 000800001, 001000003
+                    this.cardType = 'plastic';
+                    this.attendance.access_card_number = String(parseInt(cardData, 10));
                     this.attendance.source += '-' + this.cardType;
-                    this.submit();
-                } else if (pattTrackNFC.test(cardData)) {
-                    // Raw (unformatted) data from track 2 of the magnetic stripe
-                    let data = pattTrackNFC.exec(cardData)[1];
-                    console.log('NFC-prefixed cardData: ' + data);
                     cardData = null;
-                    this.attendance.gtid = data;
-                    this.attendance.source += '-contactless';
                     this.submit();
-                } else if (pattError.test(cardData)) {
-                    // Error message sent from card reader
-                    new Audio(this.sounds.error).play()
-                    console.log('error cardData: ' + pattError.exec(cardData));
+                } else if (mrd5Regex.test(cardData)) {
+                    // Transact MRD5 custom format for RoboJackets: GTID|CardNumber|CardType|
+                    // Mobile Credential: |6017700010000123|MobileA|
+                    // Plastic Credential: 902900001|800001|DESFire|
+                    const [, gtid, cardNumber, cardType] = cardData.match(mrd5Regex);
+
+                    if (gtid) {
+                      this.attendance.gtid = gtid;
+                    } else {
+                      this.attendance.access_card_number = cardNumber;
+                    }
+
+                    this.cardType = cardType;
+                    this.attendance.source += '-' + this.cardType;
                     cardData = null;
-                    Swal.fire({
-                        title: 'Hmm...',
-                        text: 'There was an error reading your card. Try again.',
-                        showConfirmButton: false,
-                        icon: 'warning',
-                        timer: 3000,
-                        timerProgressBar: true,
-                        didDestroy: () => {
-                            self.clearFields();
-                        }
-                    })
+                    this.submit();
+                } else if (tsRawRegex.test(cardData)) {
+                    // Transact Reader (MRD5, PS4101, maybe TWN4?) Raw (Non-Customized) Plastic Card Format
+                    // 1570=GTID=00=RawCardNumber (e.g. 1570=902900001=00=6017700008000010)
+                    const [, gtid, rawCardNumber] = cardData.match(bbRawRegex);
+                    const cardNumber = rawCardNumber.slice(6, 15); // drop '601770' prefix and trailing digit
+
+                    this.attendance.gtid = gtid;
+                    this.attendance.access_card_number = String(parseInt(cardNumber, 10)); // strip leading zeros
+
+                    this.cardType = 'plastic';
+                    this.attendance.source += '-' + this.cardType;
+                    cardData = null;
+                    this.submit();
                 } else {
                     Swal.close();
                     new Audio(this.sounds.error).play()

--- a/resources/js/components/attendance/AttendanceKiosk.vue
+++ b/resources/js/components/attendance/AttendanceKiosk.vue
@@ -316,10 +316,9 @@
                     }
 
                     axios
-                        .get(this.usersBaseUrl + "/search", {
+                        .get(this.usersBaseUrl + "/" + this.attendance.gtid, {
                             params: {
-                                include: 'roles',
-                                keyword: this.attendance.gtid,
+                                include: 'roles'
                             }
                         })
                         .then(response => {

--- a/resources/js/components/attendance/AttendanceKiosk.vue
+++ b/resources/js/components/attendance/AttendanceKiosk.vue
@@ -296,8 +296,8 @@
             },
             submit() {
                 // Check for lack of team selection
-                if (this.attendance.attendable_id === '') {
-                    // We have a valid card read and no team picked, check if user is an admin for hidden menu access
+                if (this.attendance.attendable_id === '' && this.attendance.gtid !== '') {
+                    // We have a valid card read with GTID and no team picked, check if user is an admin for hidden menu access
                     axios
                         .get(this.usersBaseUrl + "/search", {
                             params: {
@@ -475,6 +475,7 @@
                 //Remove focus from button
                 document.activeElement.blur();
                 this.attendance.attendable_id = '';
+                this.attendance.access_card_number = '';
                 this.attendance.gtid = '';
                 this.stickToTeam = false;
                 this.cardType = null;
@@ -484,6 +485,7 @@
             clearGTID() {
                 document.activeElement.blur();
                 this.attendance.gtid = '';
+                this.attendance.access_card_number = '';
             },
             isNumeric(n) {
                 return !isNaN(parseFloat(n)) && isFinite(n);

--- a/resources/js/components/attendance/AttendanceKiosk.vue
+++ b/resources/js/components/attendance/AttendanceKiosk.vue
@@ -298,7 +298,7 @@
                 // Check for lack of team selection
                 if (this.attendance.attendable_id === '') {
                     // We have a valid card read with and no team picked, check if user is an admin for hidden menu access
-                    if (this.attendance.gtid !== '') {
+                    if (this.attendance.gtid === '') {
                         // If there's no GTID, we can't query admin status, so assume they're not.
                         this.hasError = true;
                         this.feedback = '';

--- a/resources/js/components/attendance/AttendanceKiosk.vue
+++ b/resources/js/components/attendance/AttendanceKiosk.vue
@@ -322,8 +322,8 @@
                             }
                         })
                         .then(response => {
-                            if (response.data.users.length == 1 && typeof response.data.users[0].roles === "undefined") {
-                                // Unable to read roles? That's an error.
+                            if (response.data.status === 'error' && response.data.message !== 'User not found.') {
+                                // Got an error other than user not found (which is mildly expected for new folks)
                                 new Audio(this.sounds.error).play()
                                 console.log('Error checking permissions via API');
                                 Swal.fire(
@@ -332,7 +332,7 @@
                                     'error'
                                 );
                                 return false;
-                            } else if (response.data.users.length == 1 && response.data.users[0].roles.filter(role => role.name.toString() === "admin").length === 1) {
+                            } else if (response.data.status === 'success' && response.data.user.roles.filter(role => role.name.toString() === "admin").length === 1) {
                                 // Roles retrieved and the user is an admin
                                 let self = this;
                                 new Audio(this.sounds.notice).play()
@@ -376,8 +376,7 @@
                                 });
                                 return false;
                             } else {
-                                // Roles retried and the user is not an admin
-                                console.log('User is not an admin');
+                                // Roles retrieved and the user is not an admin
                                 new Audio(this.sounds.dohs[this.randomIntFromInterval(0, this.sounds.dohs.length - 1)]).play()
                                 Swal.fire({
                                     title: "D'oh!",

--- a/resources/js/components/attendance/AttendanceKiosk.vue
+++ b/resources/js/components/attendance/AttendanceKiosk.vue
@@ -404,7 +404,10 @@
                     let self = this;
                     Swal.showLoading();
                     axios
-                        .post(this.attendanceBaseUrl, this.attendance)
+                        .post(this.attendanceBaseUrl, Object.fromEntries(
+                          // Filter out keys with empty values to avoid server-side validation issues
+                          Object.entries(this.attendance).filter(([, v]) => v !== '' && v !== null)
+                        ))
                         .then(response => {
                             this.hasError = false;
                             let attendeeName = (response.data.attendance.attendee ? response.data.attendance.attendee.name : "Non-Member");


### PR DESCRIPTION
Fix #2749 - Update kiosk card data formats to all known current permutations including EV1 + EV3 Plastic and Mobile from various different readers/formats

This is backwards-compatible with the current reader format on the kiosk in the shop (which presents just GTID), so merging/deploying to production should not cause any issues.

The kiosk will now accept the following formats:
- GTID-only: `902900001`
- Mobile credential: sixteen-digit number starting with 601770 (e.g. `6017700010000123`)
- Plastic credential: 6-digit, 7-digit or 9-digit zero-padded (e.g. `800001`, `1000003`, `000800001`, `001000003`)
- Transact MRD5 custom format for RoboJackets: 
    `GTID|CardNumber|CardType|`
    Mobile Credential: `|6017700010000123|MobileA|`
    Plastic Credential: `902900001|800001|DESFire|`
- Transact Reader (MRD5, PS4101, maybe TWN4?) Raw (Non-Customized) Plastic Card Format
    `1570=GTID=00=RawCardNumber` (e.g. `1570=902900001=00=6017700008000010`)

Other changes:
- The "admin mode" trigger of presenting a credential belonging to a user with admin rights without selecting a team **only works with a GTID presentation** since that's what the search endpoint on the backend requires. Perhaps a later update could allow for searching by card number there in addition.