### PR TITLE
Add `debug-mrd5` permission

### DIFF
--- a/database/migrations/2026_08_25_112001_add_access_mrd5_debug_controls_permission.php
+++ b/database/migrations/2026_08_25_112001_add_access_mrd5_debug_controls_permission.php
@@ -15,7 +15,7 @@ return new class extends Migration
     {
         app()['cache']->forget('spatie.permission.cache');
 
-        $debug_mrd5 = Permission::firstOrCreate(['name' => 'debug-mrd5']);
+        $debug_mrd5 = Permission::firstOrCreate(['name' => 'access-mrd5-debug-tools']);
 
         $r_admin = Role::firstOrCreate(['name' => 'admin']);
         $r_admin->givePermissionTo($debug_mrd5);
@@ -27,6 +27,6 @@ return new class extends Migration
     public function down(): void
     {
         app()['cache']->forget('spatie.permission.cache');
-        Permission::where('name', 'debug-mrd5')->delete();
+        Permission::where('name', 'access-mrd5-debug-tools')->delete();
     }
 };

--- a/database/migrations/2026_08_25_112001_add_debug_mrd5_permission.php
+++ b/database/migrations/2026_08_25_112001_add_debug_mrd5_permission.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Spatie\Permission\Models\Permission;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        app()['cache']->forget('spatie.permission.cache');
+
+        $debug_mrd5 = Permission::firstOrCreate(['name' => 'debug-mrd5']);
+
+        $r_admin = Role::firstOrCreate(['name' => 'admin']);
+        $r_admin->givePermissionTo($debug_mrd5);
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        app()['cache']->forget('spatie.permission.cache');
+        Permission::where('name', 'debug-mrd5')->delete();
+    }
+};

--- a/database/migrations/2026_08_25_112001_add_debug_mrd5_permission.php
+++ b/database/migrations/2026_08_25_112001_add_debug_mrd5_permission.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 use Illuminate\Database\Migrations\Migration;
 use Spatie\Permission\Models\Permission;
+use Spatie\Permission\Models\Role;
 
 return new class extends Migration
 {


### PR DESCRIPTION
Adds a permission that will be used by the Android app to decide whether the advanced debug data/controls will be shown on the Connect reader screen.

- [ ] Deploy to stage