### PR TITLE
Fix/nova user resume

### DIFF
--- a/app/Models/Resume.php
+++ b/app/Models/Resume.php
@@ -112,7 +112,7 @@ class Resume extends Model
      */
     public function getStoragePathAttribute(): string
     {
-        return self::storagePathForUser($this->user);
+        return self::storageDirectory().'/'.$this->user->uid.'.pdf';
     }
 
     /**

--- a/app/Models/Resume.php
+++ b/app/Models/Resume.php
@@ -110,9 +110,9 @@ class Resume extends Model
      *
      * @psalm-mutation-free
      */
-    public function getStoragePathAttribute(): string
+    public function getStoragePathAttribute(): ?string
     {
-        return self::storageDirectory().'/'.$this->user->uid.'.pdf';
+        return $this->user ? self::storageDirectory().'/'.$this->user->uid.'.pdf' : null;
     }
 
     /**
@@ -121,17 +121,17 @@ class Resume extends Model
      *
      * @psalm-mutation-free
      */
-    public function getFileNameAttribute(): string
+    public function getFileNameAttribute(): ?string
     {
-        return $this->user->uid.'.pdf';
+        return $this->user ? $this->user->uid.'.pdf' : null;
     }
 
     /**
      * File path, complete with file name, for this Resume.
      */
-    public function getAbsoluteFilePathAttribute(): string
+    public function getAbsoluteFilePathAttribute(): ?string
     {
-        return Storage::disk(self::storageDisk())->path($this->storage_path);
+        return $this->user ? Storage::disk(self::storageDisk())->path($this->storage_path) : null;
     }
 
     /**
@@ -141,7 +141,7 @@ class Resume extends Model
      */
     public function getIsVisibleAttribute(): bool
     {
-        return self::where('id', $this->id)->visible()->count() !== 0;
+        return $this->user ? self::where('id', $this->id)->visible()->count() !== 0 : false;
     }
 
     /**

--- a/app/Models/Resume.php
+++ b/app/Models/Resume.php
@@ -19,7 +19,7 @@ use Laravel\Scout\Searchable;
  * @property int $user_id
  * @property \Illuminate\Support\Carbon|null $created_at
  * @property \Illuminate\Support\Carbon|null $updated_at
- * @property-read User $user
+ * @property-read User|null $user
  * @property-read string $file_name
  * @property-read string $absolute_file_path
  * @property-read string $storage_path


### PR DESCRIPTION
Fixes Nova User resource updates by allowing Resume->storage_path and other calculated attributes dependent on User to be nullable. Fixes Sentry.io issue:
 https://robojackets.sentry.io/issues/7694681488/?environment=production&project=5878752&query=is%3Aunresolved&referrer=issue-stream