### PR TITLE
Fix/is visible nova ordering

### DIFF
--- a/app/Models/Resume.php
+++ b/app/Models/Resume.php
@@ -150,8 +150,8 @@ class Resume extends Model
      *         or, has a non-zero payment for an active DuesPackage.
      *         Additionally, the Resume's user is a student.
      *
-     * @param  \Illuminate\Database\Eloquent\Builder<\App\Models\User>  $query
-     * @return \Illuminate\Database\Eloquent\Builder<\App\Models\User>
+     * @param  \Illuminate\Database\Eloquent\Builder<\App\Models\Resume>  $query
+     * @return \Illuminate\Database\Eloquent\Builder<\App\Models\Resume>
      */
     public function scopeVisible(Builder $query): Builder
     {

--- a/app/Nova/Resume.php
+++ b/app/Nova/Resume.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Nova;
 
 use App\Models\Resume as AppModelsResume;
+use App\Models\User as AppModelsUser;
 use App\Nova\Actions\ExportFilteredResumes;
 use App\Nova\Actions\ExportFullYearResumes;
 use Illuminate\Http\Request;
@@ -173,7 +174,7 @@ class Resume extends Resource
             $direction = $request->get('orderByDirection', 'asc');
 
             $query->addSelect([
-                'is_visible_sort' => App\Models\User::selectRaw('1')
+                'is_visible_sort' => AppModelsUser::selectRaw('1')
                     ->whereColumn('users.id', 'resumes.user_id')
                     ->active()
                     ->where('primary_affiliation', 'student')

--- a/app/Nova/Resume.php
+++ b/app/Nova/Resume.php
@@ -173,7 +173,7 @@ class Resume extends Resource
             $direction = $request->get('orderByDirection', 'asc');
 
             $query->addSelect([
-                'is_visible_sort' => User::selectRaw('1')
+                'is_visible_sort' => App\Models\User::selectRaw('1')
                     ->whereColumn('users.id', 'resumes.user_id')
                     ->active()
                     ->where('primary_affiliation', 'student')

--- a/app/Nova/Resume.php
+++ b/app/Nova/Resume.php
@@ -91,8 +91,7 @@ class Resume extends Resource
                 ->rules('required')
                 ->sortable(),
             Boolean::make('Visible to Sponsors', 'is_visible')
-                ->rules('required')
-                ->sortable(),
+                ->rules('required'),
             File::make('Resume', 'storage_path')
                 ->path('resumes')
                 ->disk('local')
@@ -159,37 +158,5 @@ class Resume extends Resource
                     ->onlyOnIndex()
                     ->canRun(static fn (): bool => true),
             ];
-    }
-
-    /**
-     * Build an "index" query for the given resource.
-     *
-     * @param  \Illuminate\Database\Eloquent\Builder<\App\Models\Resume>  $query
-     * @return \Illuminate\Database\Eloquent\Builder<\App\Models\Resume>
-     */
-    #[\Override]
-    public static function indexQuery(NovaRequest $request, $query)
-    {
-        if ($request->get('orderBy') === 'is_visible') {
-            $direction = $request->get('orderByDirection', 'asc');
-
-            $query->addSelect([
-                'is_visible_sort' => AppModelsUser::selectRaw('1')
-                    ->whereColumn('users.id', 'resumes.user_id')
-                    ->active()
-                    ->where('primary_affiliation', 'student')
-                    ->where('is_service_account', false)
-                    ->whereDoesntHave('duesPackages', static function ($q) {
-                        $q->where('restricted_to_students', false);
-                    })
-                    ->limit(1),
-            ])
-                ->orderByRaw('is_visible_sort IS NULL')
-                ->orderBy('is_visible_sort', $direction);
-
-            return $query;
-        }
-
-        return $query;
     }
 }

--- a/app/Nova/Resume.php
+++ b/app/Nova/Resume.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace App\Nova;
 
 use App\Models\Resume as AppModelsResume;
-use App\Models\User as AppModelsUser;
 use App\Nova\Actions\ExportFilteredResumes;
 use App\Nova\Actions\ExportFullYearResumes;
 use Illuminate\Http\Request;

--- a/app/Nova/Resume.php
+++ b/app/Nova/Resume.php
@@ -46,6 +46,13 @@ class Resume extends Resource
     public static $group = 'Other';
 
     /**
+     * The relationships that should be eager loaded on index queries.
+     *
+     * @var array<string>
+     */
+    public static $with = ['user'];
+
+    /**
      * The columns that should be searched.
      *
      * @var array<string>

--- a/app/Nova/Resume.php
+++ b/app/Nova/Resume.php
@@ -178,7 +178,7 @@ class Resume extends Resource
                     ->active()
                     ->where('primary_affiliation', 'student')
                     ->where('is_service_account', false)
-                    ->whereDoesntHave('duesPackages', function ($q) {
+                    ->whereDoesntHave('duesPackages', static function ($q) {
                         $q->where('restricted_to_students', false);
                     })
                     ->limit(1),

--- a/app/Nova/Resume.php
+++ b/app/Nova/Resume.php
@@ -159,4 +159,36 @@ class Resume extends Resource
                     ->canRun(static fn (): bool => true),
             ];
     }
+
+    /**
+     * Build an "index" query for the given resource.
+     *
+     * @param  \Illuminate\Database\Eloquent\Builder<\App\Models\Resume>  $query
+     * @return \Illuminate\Database\Eloquent\Builder<\App\Models\Resume>
+     */
+    #[\Override]
+    public static function indexQuery(NovaRequest $request, $query)
+    {
+        if ($request->get('orderBy') === 'is_visible') {
+            $direction = $request->get('orderByDirection', 'asc');
+
+            $query->addSelect([
+                'is_visible_sort' => User::selectRaw('1')
+                    ->whereColumn('users.id', 'resumes.user_id')
+                    ->active()
+                    ->where('primary_affiliation', 'student')
+                    ->where('is_service_account', false)
+                    ->whereDoesntHave('duesPackages', function ($q) {
+                        $q->where('restricted_to_students', false);
+                    })
+                    ->limit(1),
+            ])
+                ->orderByRaw('is_visible_sort IS NULL')
+                ->orderBy('is_visible_sort', $direction);
+
+            return $query;
+        }
+
+        return $query;
+    }
 }


### PR DESCRIPTION
Resumes' is_visible attribute is calculated, and sorting by calculated fields in Laravel Nova is not really possible by just using the sortable() function. Removed ability to sort by whether resume is visible in Nova.

Resolves Sentry.io issue [APIARY-WB](https://robojackets.sentry.io/issues/7686871468/events/9364f6d9309e4999a6a7bffb8f052904/)